### PR TITLE
Convert to 4 tabs spaces and apply code style

### DIFF
--- a/Assets/Builder.cs
+++ b/Assets/Builder.cs
@@ -5,80 +5,80 @@ using UnityEngine;
 
 public class Builder
 {
-	public static MeshData TesselatePolygon(Geometry geometry, Color color, float height)
-	{
-		var meshData = new MeshData();
-		var tess = new Tess();
+    public static MeshData TesselatePolygon(Geometry geometry, Color color, float height)
+    {
+        var meshData = new MeshData();
+        var tess = new Tess();
 
-		int pointIndex = 0;
-		foreach (var ringSize in geometry.rings)
-		{
-			var contour = new ContourVertex[ringSize];
+        int pointIndex = 0;
+        foreach (var ringSize in geometry.rings)
+        {
+            var contour = new ContourVertex[ringSize];
 
-			for (int i = pointIndex, contourIndex = 0; i < pointIndex + ringSize; ++i, ++contourIndex)
-			{
-				var point = geometry.points[i];
-				contour[contourIndex].Position = new Vec3 { X = point.x, Y = height, Z = point.y };
-			}
+            for (int i = pointIndex, contourIndex = 0; i < pointIndex + ringSize; ++i, ++contourIndex)
+            {
+                var point = geometry.points[i];
+                contour[contourIndex].Position = new Vec3 { X = point.x, Y = height, Z = point.y };
+            }
 
-			pointIndex += ringSize;
+            pointIndex += ringSize;
 
-			tess.AddContour(contour, ContourOrientation.Original);
-		}
+            tess.AddContour(contour, ContourOrientation.Original);
+        }
 
-		tess.Tessellate(WindingRule.NonZero, ElementType.Polygons, 3);
+        tess.Tessellate(WindingRule.NonZero, ElementType.Polygons, 3);
 
-		for (int i = 0; i < tess.ElementCount * 3; ++i)
-		{
-			meshData.indices.Add(tess.Elements[i]);
-		}
+        for (int i = 0; i < tess.ElementCount * 3; ++i)
+        {
+            meshData.indices.Add(tess.Elements[i]);
+        }
 
-		for (int i = 0; i < tess.VertexCount; ++i)
-		{
-			var position = tess.Vertices[i].Position;
-			meshData.vertices.Add(new Vector3(position.X, position.Y, position.Z));
-			meshData.colors.Add(color);
-		}
+        for (int i = 0; i < tess.VertexCount; ++i)
+        {
+            var position = tess.Vertices[i].Position;
+            meshData.vertices.Add(new Vector3(position.X, position.Y, position.Z));
+            meshData.colors.Add(color);
+        }
 
-		return meshData;
-	}
+        return meshData;
+    }
 
-	public static MeshData TesselatePolygonExtrusion(Geometry geometry, Color color, float minHeight, float height)
-	{
-		var meshData = new MeshData();
-		int pointIndex = 0;
-		int indexOffset = 0;
+    public static MeshData TesselatePolygonExtrusion(Geometry geometry, Color color, float minHeight, float height)
+    {
+        var meshData = new MeshData();
+        int pointIndex = 0;
+        int indexOffset = 0;
 
-		foreach (var ringSize in geometry.rings)
-		{
-			for (int i = pointIndex; i < pointIndex + ringSize - 1; i++)
-			{
-				var p0 = geometry.points[i];
-				var p1 = geometry.points[i+1];
+        foreach (var ringSize in geometry.rings)
+        {
+            for (int i = pointIndex; i < pointIndex + ringSize - 1; i++)
+            {
+                var p0 = geometry.points[i];
+                var p1 = geometry.points[i + 1];
 
-				meshData.vertices.Add(new Vector3(p0.x, height, p0.y));
-				meshData.vertices.Add(new Vector3(p1.x, height, p1.y));
-				meshData.vertices.Add(new Vector3(p0.x, minHeight, p0.y));
-				meshData.vertices.Add(new Vector3(p1.x, minHeight, p1.y));
+                meshData.vertices.Add(new Vector3(p0.x, height, p0.y));
+                meshData.vertices.Add(new Vector3(p1.x, height, p1.y));
+                meshData.vertices.Add(new Vector3(p0.x, minHeight, p0.y));
+                meshData.vertices.Add(new Vector3(p1.x, minHeight, p1.y));
 
-				for (int colorIndex = 0; colorIndex < 4; ++colorIndex)
-				{
-					meshData.colors.Add(color);
-				}
+                for (int colorIndex = 0; colorIndex < 4; ++colorIndex)
+                {
+                    meshData.colors.Add(color);
+                }
 
-				meshData.indices.Add(indexOffset + 2);
-				meshData.indices.Add(indexOffset + 3);
-				meshData.indices.Add(indexOffset + 1);
-				meshData.indices.Add(indexOffset + 2);
-				meshData.indices.Add(indexOffset + 1);
-				meshData.indices.Add(indexOffset + 0);
+                meshData.indices.Add(indexOffset + 2);
+                meshData.indices.Add(indexOffset + 3);
+                meshData.indices.Add(indexOffset + 1);
+                meshData.indices.Add(indexOffset + 2);
+                meshData.indices.Add(indexOffset + 1);
+                meshData.indices.Add(indexOffset + 0);
 
-				indexOffset += 4;
-			}
+                indexOffset += 4;
+            }
 
-			pointIndex += ringSize;
-		}
+            pointIndex += ringSize;
+        }
 
-		return meshData;
-	}
+        return meshData;
+    }
 }

--- a/Assets/MapTile.cs
+++ b/Assets/MapTile.cs
@@ -8,68 +8,69 @@ using LibTessDotNet;
 [RequireComponent(typeof(MeshFilter))]
 public class MapTile : MonoBehaviour
 {
-	private MeshData meshData;
+    private MeshData meshData;
 
-	private Dictionary<String, Color> layerColors = new Dictionary<String, Color> {
-			{ "water", Color.blue },
-			{ "earth", Color.green },
-			{ "roads", Color.gray },
-			{ "buildings", Color.black },
-	};
+    private Dictionary<String, Color> layerColors = new Dictionary<String, Color>
+    {
+        { "water", Color.blue },
+        { "earth", Color.green },
+        { "roads", Color.gray },
+        { "buildings", Color.black },
+    };
 
-	public void BuildMesh(double tileScale, List<FeatureCollection> layers)
-	{
-		meshData = new MeshData();
-		float inverseTileScale = 1.0f / (float)tileScale;
+    public void BuildMesh(double tileScale, List<FeatureCollection> layers)
+    {
+        meshData = new MeshData();
+        float inverseTileScale = 1.0f / (float)tileScale;
 
-		foreach (var layer in layers)
-		{
-			Color color = layerColors[layer.name];
+        foreach (var layer in layers)
+        {
+            Color color = layerColors[layer.name];
 
-			foreach (var feature in layer.features)
-			{
-				// TODO: use extrusion scale and minHeight as options
-				float height = 0.0f;
-				float minHeight = 0.0f;
+            foreach (var feature in layer.features)
+            {
+                // TODO: use extrusion scale and minHeight as options
+                float height = 0.0f;
+                float minHeight = 0.0f;
 
-				JSONNode heightNode;
-				if (feature.TryGetProperty("height", out heightNode))
-				{
-					height = heightNode * inverseTileScale;
-				}
+                JSONNode heightNode;
+                if (feature.TryGetProperty("height", out heightNode))
+                {
+                    height = heightNode * inverseTileScale;
+                }
 
-				if (feature.geometry.type == GeometryType.Polygon)
-				{
-					var polygonMeshData = Builder.TesselatePolygon(feature.geometry, color, height);
-					meshData.Add(polygonMeshData);
+                if (feature.geometry.type == GeometryType.Polygon)
+                {
+                    var polygonMeshData = Builder.TesselatePolygon(feature.geometry, color, height);
+                    meshData.Add(polygonMeshData);
 
-					if (height > 0.0f)
-					{
-						var extrusionMeshData = Builder.TesselatePolygonExtrusion(feature.geometry, color, minHeight, height);
-						meshData.Add(extrusionMeshData);
-					}
-				}
-			}
-		}
+                    if (height > 0.0f)
+                    {
+                        var extrusionMeshData = Builder.TesselatePolygonExtrusion(feature.geometry, color, minHeight, height);
+                        meshData.Add(extrusionMeshData);
+                    }
+                }
+            }
+        }
 
-		meshData.FlipIndices();
-	}
+        meshData.FlipIndices();
+    }
 
-	public void CreateUnityMesh(float offsetX, float offsetY)
-	{
-		var mesh = new Mesh();
-		GetComponent<MeshFilter>().mesh = mesh;
+    public void CreateUnityMesh(float offsetX, float offsetY)
+    {
+        var mesh = new Mesh();
+        GetComponent<MeshFilter>().mesh = mesh;
 
-		mesh.vertices = meshData.vertices.ToArray();
-		mesh.triangles = meshData.indices.ToArray();
-		mesh.colors = meshData.colors.ToArray();
-		mesh.RecalculateNormals();
+        mesh.vertices = meshData.vertices.ToArray();
+        mesh.triangles = meshData.indices.ToArray();
+        mesh.colors = meshData.colors.ToArray();
+        mesh.RecalculateNormals();
 
-		transform.Translate(new Vector3(offsetX, 0.0f, offsetY));
-	}
+        transform.Translate(new Vector3(offsetX, 0.0f, offsetY));
+    }
 
-	public void Update()
-	{
-		//transform.Rotate(Vector3.up, Time.deltaTime * 10.0f);
-	}
+    public void Update()
+    {
+        //transform.Rotate(Vector3.up, Time.deltaTime * 10.0f);
+    }
 }

--- a/Assets/Mapzen/Geo.cs
+++ b/Assets/Mapzen/Geo.cs
@@ -2,24 +2,24 @@
 
 namespace Mapzen
 {
-	public class Geo
-	{
-		public static readonly double EarthRadiusMeters = 6378137.0;
-		public static readonly double EarthCircumferenceMeters = EarthRadiusMeters * Math.PI * 2.0;
-		public static readonly double EarthHalfCircumferenceMeters = EarthRadiusMeters * Math.PI;
+    public class Geo
+    {
+        public static readonly double EarthRadiusMeters = 6378137.0;
+        public static readonly double EarthCircumferenceMeters = EarthRadiusMeters * Math.PI * 2.0;
+        public static readonly double EarthHalfCircumferenceMeters = EarthRadiusMeters * Math.PI;
 
-		public static MercatorMeters Project(LngLat lngLat)
-		{
-			double x = lngLat.longitude * EarthHalfCircumferenceMeters / 180.0 + EarthHalfCircumferenceMeters;
-			double y = -Math.Log(Math.Tan(0.25 * Math.PI + lngLat.latitude * Math.PI / 360.0)) * EarthRadiusMeters + EarthHalfCircumferenceMeters;
-			return new MercatorMeters(x, y);
-		}
+        public static MercatorMeters Project(LngLat lngLat)
+        {
+            double x = lngLat.longitude * EarthHalfCircumferenceMeters / 180.0 + EarthHalfCircumferenceMeters;
+            double y = -Math.Log(Math.Tan(0.25 * Math.PI + lngLat.latitude * Math.PI / 360.0)) * EarthRadiusMeters + EarthHalfCircumferenceMeters;
+            return new MercatorMeters(x, y);
+        }
 
-		public static LngLat Unproject(MercatorMeters meters)
-		{
-			double longitude = (meters.x - EarthHalfCircumferenceMeters) * 180.0 / EarthHalfCircumferenceMeters;
-			double latitude = (Math.Atan(Math.Exp((-meters.y + EarthHalfCircumferenceMeters) / EarthRadiusMeters)) - 0.25 * Math.PI) * 360.0 / Math.PI;
-			return new LngLat(longitude, latitude);
-		}
-	}
+        public static LngLat Unproject(MercatorMeters meters)
+        {
+            double longitude = (meters.x - EarthHalfCircumferenceMeters) * 180.0 / EarthHalfCircumferenceMeters;
+            double latitude = (Math.Atan(Math.Exp((-meters.y + EarthHalfCircumferenceMeters) / EarthRadiusMeters)) - 0.25 * Math.PI) * 360.0 / Math.PI;
+            return new LngLat(longitude, latitude);
+        }
+    }
 }

--- a/Assets/Mapzen/LngLat.cs
+++ b/Assets/Mapzen/LngLat.cs
@@ -2,26 +2,26 @@
 
 namespace Mapzen
 {
-	public struct LngLat
-	{
-		public LngLat(double lng, double lat)
-		{
-			longitude = lng;
-			latitude = lat;
-		}
+    public struct LngLat
+    {
+        public LngLat(double lng, double lat)
+        {
+            longitude = lng;
+            latitude = lat;
+        }
 
-		public double longitude;
-		public double latitude;
+        public double longitude;
+        public double latitude;
 
-		public LngLat WrappedToPositive()
-		{
-			return new LngLat(longitude - Math.Floor(longitude / 360.0) * 360.0,
-							  latitude - Math.Round(latitude / 180.0) * 180.0);
-		}
+        public LngLat WrappedToPositive()
+        {
+            return new LngLat(longitude - Math.Floor(longitude / 360.0) * 360.0,
+                latitude - Math.Round(latitude / 180.0) * 180.0);
+        }
 
-		public MercatorMeters ToMercatorMeters()
-		{
-			return Geo.Project(this);
-		}
-	}
+        public MercatorMeters ToMercatorMeters()
+        {
+            return Geo.Project(this);
+        }
+    }
 }

--- a/Assets/Mapzen/MercatorMeters.cs
+++ b/Assets/Mapzen/MercatorMeters.cs
@@ -2,21 +2,20 @@
 
 namespace Mapzen
 {
-	public class MercatorMeters
-	{
-		public MercatorMeters(double x, double y)
-		{
-			this.x = x;
-			this.y = y;
-		}
+    public class MercatorMeters
+    {
+        public MercatorMeters(double x, double y)
+        {
+            this.x = x;
+            this.y = y;
+        }
 
-		public double x;
-		public double y;
+        public double x;
+        public double y;
 
-		public LngLat ToLngLat()
-		{
-			return Geo.Unproject(this);
-		}
-
-	}
+        public LngLat ToLngLat()
+        {
+            return Geo.Unproject(this);
+        }
+    }
 }

--- a/Assets/Mapzen/TileAddress.cs
+++ b/Assets/Mapzen/TileAddress.cs
@@ -2,95 +2,95 @@
 
 namespace Mapzen
 {
-	public struct TileAddress : IComparable, IEquatable<TileAddress>
-	{
-		public TileAddress(int x, int y, int z)
-		{
-			int max = 1 << z;
-			this.x = x % max;
-			this.y = y % max;
-			this.z = z;
-		}
+    public struct TileAddress : IComparable, IEquatable<TileAddress>
+    {
+        public TileAddress(int x, int y, int z)
+        {
+            int max = 1 << z;
+            this.x = x % max;
+            this.y = y % max;
+            this.z = z;
+        }
 
-		public readonly int x;
-		public readonly int y;
-		public readonly int z;
+        public readonly int x;
+        public readonly int y;
+        public readonly int z;
 
-		public TileAddress GetParent()
-		{
-			return new TileAddress(x >> 1, y >> 1, z - 1);
-		}
+        public TileAddress GetParent()
+        {
+            return new TileAddress(x >> 1, y >> 1, z - 1);
+        }
 
-		public TileAddress[] GetChildren()
-		{
-			var children = new TileAddress[4];
-			int cx = x << 1;
-			int cy = y << 1;
-			int cz = z + 1;
-			children[0] = new TileAddress(cx + 0, cy + 0, cz);
-			children[1] = new TileAddress(cx + 0, cy + 1, cz);
-			children[2] = new TileAddress(cx + 1, cy + 0, cz);
-			children[3] = new TileAddress(cx + 1, cy + 1, cz);
-			return children;
-		}
+        public TileAddress[] GetChildren()
+        {
+            var children = new TileAddress[4];
+            int cx = x << 1;
+            int cy = y << 1;
+            int cz = z + 1;
+            children[0] = new TileAddress(cx + 0, cy + 0, cz);
+            children[1] = new TileAddress(cx + 0, cy + 1, cz);
+            children[2] = new TileAddress(cx + 1, cy + 0, cz);
+            children[3] = new TileAddress(cx + 1, cy + 1, cz);
+            return children;
+        }
 
-		public double GetSizeMercatorMeters()
-		{
-			return Geo.EarthCircumferenceMeters / (1 << z);
-		}
+        public double GetSizeMercatorMeters()
+        {
+            return Geo.EarthCircumferenceMeters / (1 << z);
+        }
 
-		public MercatorMeters GetOriginMercatorMeters()
-		{
-			double metersPerTile = GetSizeMercatorMeters();
-			return new MercatorMeters(x * metersPerTile, y * metersPerTile);
-		}
+        public MercatorMeters GetOriginMercatorMeters()
+        {
+            double metersPerTile = GetSizeMercatorMeters();
+            return new MercatorMeters(x * metersPerTile, y * metersPerTile);
+        }
 
-		public int CompareTo(object obj)
-		{
-			if (!(obj is TileAddress))
-			{
-				return 1;
-			}
-			var other = (TileAddress)obj;
-			if (z != other.z)
-			{
-				// Lower z precedes higher z.
-				return z - other.z;
-			}
-			if (x != other.x)
-			{
-				// Lower x precedes higher x.
-				return x - other.x;
-			}
-			if (y != other.y)
-			{
-				// Lower y precedes higher y.
-				return y - other.y;
-			}
-			// The addresses are equal.
-			return 0;
-		}
+        public int CompareTo(object obj)
+        {
+            if (!(obj is TileAddress))
+            {
+                return 1;
+            }
+            var other = (TileAddress)obj;
+            if (z != other.z)
+            {
+                // Lower z precedes higher z.
+                return z - other.z;
+            }
+            if (x != other.x)
+            {
+                // Lower x precedes higher x.
+                return x - other.x;
+            }
+            if (y != other.y)
+            {
+                // Lower y precedes higher y.
+                return y - other.y;
+            }
+            // The addresses are equal.
+            return 0;
+        }
 
-		public bool Equals(TileAddress other)
-		{
-			return (z == other.z) && ((y == other.y) && (x == other.x));
-		}
+        public bool Equals(TileAddress other)
+        {
+            return (z == other.z) && ((y == other.y) && (x == other.x));
+        }
 
-		public override bool Equals(object obj)
-		{
-			if (obj is TileAddress)
-			{
-				return Equals((TileAddress)obj);
-			}
-			return false;
-		}
+        public override bool Equals(object obj)
+        {
+            if (obj is TileAddress)
+            {
+                return Equals((TileAddress)obj);
+            }
+            return false;
+        }
 
-		public override int GetHashCode()
-		{
-			// TODO: Find a hash function with better distribution.
-			return (z ^ x) ^ y;
-		}
+        public override int GetHashCode()
+        {
+            // TODO: Find a hash function with better distribution.
+            return (z ^ x) ^ y;
+        }
 
 
-	}
+    }
 }

--- a/Assets/Mapzen/VectorData/Feature.cs
+++ b/Assets/Mapzen/VectorData/Feature.cs
@@ -2,31 +2,32 @@
 
 namespace Mapzen.VectorData
 {
-	public class Feature
-	{
-		public Feature()
-		{
-			geometry = new Geometry();
-			properties = new Dictionary<string, object>();
-		}
+    public class Feature
+    {
+        public Feature()
+        {
+            geometry = new Geometry();
+            properties = new Dictionary<string, object>();
+        }
 
-		public Geometry geometry { get; set; }
-		public Dictionary<string, object> properties { get; set; }
+        public Geometry geometry { get; set; }
 
-		public bool TryGetProperty<N>(string propertyKey, out N node)
-		{
-			object propertyValue;
-			if (properties.TryGetValue(propertyKey, out propertyValue))
-			{
-				var propertyNode = (N)propertyValue;
-				if (propertyNode != null)
-				{
-					node = propertyNode;
-					return true;
-				}
-			}
-			node = default(N);
-			return false;
-		}
-	}
+        public Dictionary<string, object> properties { get; set; }
+
+        public bool TryGetProperty<N>(string propertyKey, out N node)
+        {
+            object propertyValue;
+            if (properties.TryGetValue(propertyKey, out propertyValue))
+            {
+                var propertyNode = (N)propertyValue;
+                if (propertyNode != null)
+                {
+                    node = propertyNode;
+                    return true;
+                }
+            }
+            node = default(N);
+            return false;
+        }
+    }
 }

--- a/Assets/Mapzen/VectorData/FeatureCollection.cs
+++ b/Assets/Mapzen/VectorData/FeatureCollection.cs
@@ -2,15 +2,15 @@
 
 namespace Mapzen.VectorData
 {
-	public class FeatureCollection
-	{
-		public FeatureCollection(string name = "")
-		{
-			this.name = name;
-			this.features = new List<Feature>();
-		}
+    public class FeatureCollection
+    {
+        public FeatureCollection(string name = "")
+        {
+            this.name = name;
+            this.features = new List<Feature>();
+        }
 
-		public string name;
-		public List<Feature> features;
-	}
+        public string name;
+        public List<Feature> features;
+    }
 }

--- a/Assets/Mapzen/VectorData/GeoJSON.cs
+++ b/Assets/Mapzen/VectorData/GeoJSON.cs
@@ -5,185 +5,193 @@ using Mapzen.VectorData;
 
 namespace Mapzen
 {
-	public class GeoJSON
-	{
-		public delegate Point LocalCoordinateProjection(LngLat lngLat);
+    public class GeoJSON
+    {
+        public delegate Point LocalCoordinateProjection(LngLat lngLat);
 
-		public static LocalCoordinateProjection LocalCoordinateProjectionForTile(TileAddress address)
-		{
-			return delegate(LngLat lngLat) {
-				var meters = lngLat.ToMercatorMeters();
-				var origin = address.GetOriginMercatorMeters();
-				var scale = address.GetSizeMercatorMeters();
-				var x = (meters.x - origin.x) / scale;
-				var y = (meters.y - origin.y) / scale;
-				return new Point((float)x, (float)y);
-			};
-		}
+        public static LocalCoordinateProjection LocalCoordinateProjectionForTile(TileAddress address)
+        {
+            return delegate(LngLat lngLat)
+            {
+                var meters = lngLat.ToMercatorMeters();
+                var origin = address.GetOriginMercatorMeters();
+                var scale = address.GetSizeMercatorMeters();
+                var x = (meters.x - origin.x) / scale;
+                var y = (meters.y - origin.y) / scale;
+                return new Point((float)x, (float)y);
+            };
+        }
 
-		private JSONNode root;
-		private LocalCoordinateProjection transform;
+        private JSONNode root;
+        private LocalCoordinateProjection transform;
 
-		public GeoJSON(string geoJSONDataString, LocalCoordinateProjection transform)
-		{
-			root = JSON.Parse(geoJSONDataString);
-			this.transform = transform;
-		}
+        public GeoJSON(string geoJSONDataString, LocalCoordinateProjection transform)
+        {
+            root = JSON.Parse(geoJSONDataString);
+            this.transform = transform;
+        }
 
-		public List<FeatureCollection> GetLayersByName(List<string> layerNames)
-		{
-			if (root == null) {
-				return null;
-			}
+        public List<FeatureCollection> GetLayersByName(List<string> layerNames)
+        {
+            if (root == null)
+            {
+                return null;
+            }
 
-			var layers = new List<FeatureCollection>();
+            var layers = new List<FeatureCollection>();
 
-			foreach (string name in layerNames)
-			{
-				JSONNode layerNode = root[name];
+            foreach (string name in layerNames)
+            {
+                JSONNode layerNode = root[name];
 
-				if (layerNode == null)
-				{
-					Console.WriteLine("Can't find layer '{0}' in GeoJSON data.", name);
-					continue;
-				}
+                if (layerNode == null)
+                {
+                    Console.WriteLine("Can't find layer '{0}' in GeoJSON data.", name);
+                    continue;
+                }
 
-				var layer = GetLayer(layerNode, name);
-				layers.Add(layer);
-			}
-			return layers;
-		}
+                var layer = GetLayer(layerNode, name);
+                layers.Add(layer);
+            }
+            return layers;
+        }
 
-		FeatureCollection GetLayer(JSONNode layerNode, string layerName)
-		{
-			var layer = new FeatureCollection(layerName);
+        FeatureCollection GetLayer(JSONNode layerNode, string layerName)
+        {
+            var layer = new FeatureCollection(layerName);
 
-			JSONNode features = layerNode["features"];
+            JSONNode features = layerNode["features"];
 
-			if (features == null)
-			{
-				return layer;
-			}
+            if (features == null)
+            {
+                return layer;
+            }
 
-			foreach (JSONNode feature in features.Children)
-			{
-				layer.features.Add(GetFeature(feature));
-			}
+            foreach (JSONNode feature in features.Children)
+            {
+                layer.features.Add(GetFeature(feature));
+            }
 
-			return layer;
-		}
+            return layer;
+        }
 
-		Feature GetFeature(JSONNode featureNode)
-		{
-			Feature feature = new Feature();
+        Feature GetFeature(JSONNode featureNode)
+        {
+            Feature feature = new Feature();
 
-			JSONNode propertiesNode = featureNode["properties"];
-			if (propertiesNode != null && propertiesNode.IsObject)
-			{
-				foreach (KeyValuePair<string, JSONNode> property in propertiesNode.AsObject)
-				{
-					// TODO: Define more strict typing on property values.
-					feature.properties.Add(property.Key, property.Value);
-				}
-			}
+            JSONNode propertiesNode = featureNode["properties"];
+            if (propertiesNode != null && propertiesNode.IsObject)
+            {
+                foreach (KeyValuePair<string, JSONNode> property in propertiesNode.AsObject)
+                {
+                    // TODO: Define more strict typing on property values.
+                    feature.properties.Add(property.Key, property.Value);
+                }
+            }
 
-			JSONNode geometryNode = featureNode["geometry"];
-			if (geometryNode != null)
-			{
-				feature.geometry = GetGeometry(geometryNode);
-			}
+            JSONNode geometryNode = featureNode["geometry"];
+            if (geometryNode != null)
+            {
+                feature.geometry = GetGeometry(geometryNode);
+            }
 
-			return feature;
-		}
+            return feature;
+        }
 
-		Geometry GetGeometry(JSONNode geometryNode)
-		{
-			JSONNode coords = geometryNode["coordinates"];
-			JSONNode type = geometryNode["type"];
+        Geometry GetGeometry(JSONNode geometryNode)
+        {
+            JSONNode coords = geometryNode["coordinates"];
+            JSONNode type = geometryNode["type"];
 
-			if (type != null && coords != null)
-			{
-				switch (type.Value)
-				{
-					case "Point": return GetPointGeometry(coords);
-					case "MultiPoint": return GetMultiPointGeometry(coords);
-					case "LineString": return GetLineStringGeometry(coords);
-					case "MultiLineString": return GetMultiLineStringGeometry(coords);
-					case "Polygon": return GetPolygonGeometry(coords);
-					case "MultiPolygon": return GetMultiPolygonGeometry(coords);
-				}
-			}
-			return new Geometry();
-		}
+            if (type != null && coords != null)
+            {
+                switch (type.Value)
+                {
+                    case "Point":
+                        return GetPointGeometry(coords);
+                    case "MultiPoint":
+                        return GetMultiPointGeometry(coords);
+                    case "LineString":
+                        return GetLineStringGeometry(coords);
+                    case "MultiLineString":
+                        return GetMultiLineStringGeometry(coords);
+                    case "Polygon":
+                        return GetPolygonGeometry(coords);
+                    case "MultiPolygon":
+                        return GetMultiPolygonGeometry(coords);
+                }
+            }
+            return new Geometry();
+        }
 
-		Point GetPoint(JSONNode coords)
-		{
-			var lngLat = new LngLat(coords[0].AsDouble, coords[1].AsDouble);
-			return transform(lngLat);
-		}
+        Point GetPoint(JSONNode coords)
+        {
+            var lngLat = new LngLat(coords[0].AsDouble, coords[1].AsDouble);
+            return transform(lngLat);
+        }
 
-		Geometry GetPointGeometry(JSONNode coords)
-		{
-			var geometry = new Geometry();
-			geometry.type = GeometryType.Point;
-			geometry.points.Add(GetPoint(coords));
-			return geometry;
-		}
+        Geometry GetPointGeometry(JSONNode coords)
+        {
+            var geometry = new Geometry();
+            geometry.type = GeometryType.Point;
+            geometry.points.Add(GetPoint(coords));
+            return geometry;
+        }
 
-		Geometry GetMultiPointGeometry(JSONNode coords)
-		{
-			var geometry = new Geometry();
-			geometry.type = GeometryType.Point;
-			foreach (JSONNode pointCoords in coords.Children)
-			{
-				geometry.points.Add(GetPoint(pointCoords));
-			}
-			return geometry;
-		}
+        Geometry GetMultiPointGeometry(JSONNode coords)
+        {
+            var geometry = new Geometry();
+            geometry.type = GeometryType.Point;
+            foreach (JSONNode pointCoords in coords.Children)
+            {
+                geometry.points.Add(GetPoint(pointCoords));
+            }
+            return geometry;
+        }
 
-		Geometry GetLineStringGeometry(JSONNode coords)
-		{
-			var geometry = GetMultiPointGeometry(coords);
-			geometry.type = GeometryType.LineString;
-			return geometry;
-		}
+        Geometry GetLineStringGeometry(JSONNode coords)
+        {
+            var geometry = GetMultiPointGeometry(coords);
+            geometry.type = GeometryType.LineString;
+            return geometry;
+        }
 
-		Geometry GetMultiLineStringGeometry(JSONNode coords)
-		{
-			var geometry = new Geometry();
-			geometry.type = GeometryType.LineString;
-			int segmentEndIndex = 0;
-			foreach (JSONNode lineStringCoords in coords.Children)
-			{
-				foreach (JSONNode pointCoords in lineStringCoords.Children)
-				{
-					geometry.points.Add(GetPoint(pointCoords));
-				}
-				geometry.rings.Add(geometry.points.Count - segmentEndIndex);
-				segmentEndIndex = geometry.points.Count;
-			}
-			return geometry;
-		}
+        Geometry GetMultiLineStringGeometry(JSONNode coords)
+        {
+            var geometry = new Geometry();
+            geometry.type = GeometryType.LineString;
+            int segmentEndIndex = 0;
+            foreach (JSONNode lineStringCoords in coords.Children)
+            {
+                foreach (JSONNode pointCoords in lineStringCoords.Children)
+                {
+                    geometry.points.Add(GetPoint(pointCoords));
+                }
+                geometry.rings.Add(geometry.points.Count - segmentEndIndex);
+                segmentEndIndex = geometry.points.Count;
+            }
+            return geometry;
+        }
 
-		Geometry GetPolygonGeometry(JSONNode coords)
-		{
-			var geometry = GetMultiLineStringGeometry(coords);
-			geometry.type = GeometryType.Polygon;
-			return geometry;
-		}
+        Geometry GetPolygonGeometry(JSONNode coords)
+        {
+            var geometry = GetMultiLineStringGeometry(coords);
+            geometry.type = GeometryType.Polygon;
+            return geometry;
+        }
 
-		Geometry GetMultiPolygonGeometry(JSONNode coords)
-		{
-                        var geometry = new Geometry();
-                        geometry.type = GeometryType.Polygon;
-                        foreach (JSONNode polygonCoordinates in coords.Children)
-                        {
-                                var polygonGeometry = GetPolygonGeometry(polygonCoordinates);
-                                geometry.rings.AddRange(polygonGeometry.rings);
-                                geometry.points.AddRange(polygonGeometry.points);
-                        }
-                        return geometry;
-		}
-	}
+        Geometry GetMultiPolygonGeometry(JSONNode coords)
+        {
+            var geometry = new Geometry();
+            geometry.type = GeometryType.Polygon;
+            foreach (JSONNode polygonCoordinates in coords.Children)
+            {
+                var polygonGeometry = GetPolygonGeometry(polygonCoordinates);
+                geometry.rings.AddRange(polygonGeometry.rings);
+                geometry.points.AddRange(polygonGeometry.points);
+            }
+            return geometry;
+        }
+    }
 }
 

--- a/Assets/Mapzen/VectorData/Geometry.cs
+++ b/Assets/Mapzen/VectorData/Geometry.cs
@@ -2,10 +2,10 @@
 
 namespace Mapzen.VectorData
 {
-	public class Geometry
-	{
-		public List<Point> points = new List<Point>();
-		public List<int> rings = new List<int>();
-		public GeometryType type = GeometryType.Unknown;
-	}
+    public class Geometry
+    {
+        public List<Point> points = new List<Point>();
+        public List<int> rings = new List<int>();
+        public GeometryType type = GeometryType.Unknown;
+    }
 }

--- a/Assets/Mapzen/VectorData/GeometryType.cs
+++ b/Assets/Mapzen/VectorData/GeometryType.cs
@@ -1,10 +1,10 @@
 ﻿namespace Mapzen.VectorData
 {
-	public enum GeometryType
-	{
-		Unknown = 0,
-		Point = 1,
-		LineString = 2,
-		Polygon = 3,
-	}
+    public enum GeometryType
+    {
+        Unknown = 0,
+        Point = 1,
+        LineString = 2,
+        Polygon = 3,
+    }
 }

--- a/Assets/Mapzen/VectorData/Point.cs
+++ b/Assets/Mapzen/VectorData/Point.cs
@@ -1,15 +1,15 @@
 ﻿
 namespace Mapzen.VectorData
 {
-	public struct Point
-	{
-		public Point(float x, float y)
-		{
-			this.x = x;
-			this.y = y;
-		}
+    public struct Point
+    {
+        public Point(float x, float y)
+        {
+            this.x = x;
+            this.y = y;
+        }
 
-		public float x;
-		public float y;
-	}
+        public float x;
+        public float y;
+    }
 }

--- a/Assets/MapzenMap.cs
+++ b/Assets/MapzenMap.cs
@@ -4,114 +4,116 @@ using UnityEngine;
 using UnityEngine.Networking;
 using Mapzen;
 
-public class MapzenMap : MonoBehaviour {
+public class MapzenMap : MonoBehaviour
+{
+    delegate void HTTPRequestCallback(string error,string response,TileAddress address);
 
-	delegate void HTTPRequestCallback(string error, string response, TileAddress address);
+    public int TileX = 19290;
+    public int TileY = 24632;
+    public int TileZ = 16;
 
-	public int TileX = 19290;
-	public int TileY = 24632;
-	public int TileZ = 16;
+    public int TileRangeX = 5;
+    public int TileRangeY = 5;
 
-	public int TileRangeX = 5;
-	public int TileRangeY = 5;
+    public string ApiKey = "vector-tiles-tyHL4AY";
 
-	public string ApiKey = "vector-tiles-tyHL4AY";
+    private List<TileTask> pendingTasks = new List<TileTask>();
+    private AsyncWorker worker = new AsyncWorker(4);
 
-	private List<TileTask> pendingTasks = new List<TileTask>();
-	private AsyncWorker worker = new AsyncWorker(4);
+    void Start()
+    {
+        // Construct the HTTP request
+        for (int x = 0; x < TileRangeX; ++x)
+        {
+            for (int y = 0; y < TileRangeY; ++y)
+            {
+                int tileX = TileX + x;
+                int tileY = TileY + y;
 
-	void Start()
-	{
-		// Construct the HTTP request
-		for (int x = 0; x < TileRangeX; ++x)
-		{
-			for (int y = 0; y < TileRangeY; ++y)
-			{
-				int tileX = TileX + x;
-				int tileY = TileY + y;
+                var url = string.Format("https://tile.mapzen.com/mapzen/vector/v1/all/{0}/{1}/{2}.json?api_key={3}",
+                              TileZ, tileX, tileY, ApiKey);
 
-				var url = string.Format("https://tile.mapzen.com/mapzen/vector/v1/all/{0}/{1}/{2}.json?api_key={3}",
-					TileZ, tileX, tileY, ApiKey);
+                Debug.Log("URL request " + url);
 
-				Debug.Log("URL request " + url);
+                HTTPRequestCallback callback = (string error, string response, TileAddress address) =>
+                {
+                    if (error != null)
+                    {
+                        Debug.Log("Error: " + error);
+                        return;
+                    }
 
-				HTTPRequestCallback callback = (string error, string response, TileAddress address) =>
-				{
-					if (error != null)
-					{
-						Debug.Log("Error: " + error);
-						return;
-					}
+                    if (response.Length == 0)
+                    {
+                        Debug.Log("Empty response");
+                        return;
+                    }
 
-					if (response.Length == 0)
-					{
-						Debug.Log("Empty response");
-						return;
-					}
+                    Debug.Log("Response: " + response);
 
-					Debug.Log("Response: " + response);
+                    // Adding a tile object to the scene
+                    GameObject tilePrefab = Resources.Load("Tile") as GameObject;
 
-					// Adding a tile object to the scene
-					GameObject tilePrefab = Resources.Load("Tile") as GameObject;
+                    // Instantiate a prefab running the script TileData.Start()
+                    var go = Instantiate(tilePrefab);
 
-					// Instantiate a prefab running the script TileData.Start()
-					var go = Instantiate(tilePrefab);
+                    MapTile tile = go.GetComponent<MapTile>();
 
-					MapTile tile = go.GetComponent<MapTile>();
+                    var layers = new List<string>
+                    {
+                        "water",
+                        "roads",
+                        "earth",
+                        "buildings"
+                    };
 
-					var layers = new List<string> {
-						"water",
-						"roads",
-						"earth",
-						"buildings"
-					};
+                    TileTask task = new TileTask(address, layers, response, tile);
 
-					TileTask task = new TileTask(address, layers, response, tile);
+                    task.offsetX = (address.x - TileX);
+                    task.offsetY = (address.y - TileY);
 
-					task.offsetX = (address.x - TileX);
-					task.offsetY = (address.y - TileY);
+                    pendingTasks.Add(task);
 
-					pendingTasks.Add(task);
+                    worker.RunAsync(() =>
+                        {
+                            task.Start();
+                        });
+                };
+                UnityWebRequest request = UnityWebRequest.Get(url);
 
-					worker.RunAsync(() => {
-						task.Start();
-					});
-				};
-				UnityWebRequest request = UnityWebRequest.Get(url);
+                // Starts the HTTP request
+                StartCoroutine(DoHTTPRequest(request, callback, new TileAddress(tileX, tileY, TileZ)));
+            }
+        }
+    }
 
-				// Starts the HTTP request
-				StartCoroutine(DoHTTPRequest(request, callback, new TileAddress(tileX, tileY, TileZ)));
-			}
-		}
-	}
+    // Runs an HTTP request
+    IEnumerator DoHTTPRequest(UnityWebRequest request, HTTPRequestCallback callback, TileAddress address)
+    {
+        yield return request.Send();
 
-	// Runs an HTTP request
-	IEnumerator DoHTTPRequest(UnityWebRequest request, HTTPRequestCallback callback, TileAddress address)
-	{
-		yield return request.Send();
+        string data = System.Text.Encoding.Default.GetString(request.downloadHandler.data);
 
-		string data = System.Text.Encoding.Default.GetString(request.downloadHandler.data);
+        callback(request.error, data, address);
+    }
 
-		callback(request.error, data, address);
-	}
+    // Update is called once per frame
+    void Update()
+    {
+        List<TileTask> readyTasks = new List<TileTask>();
 
-	// Update is called once per frame
-	void Update()
-	{
-		List<TileTask> readyTasks = new List<TileTask>();
+        foreach (TileTask task in pendingTasks)
+        {
+            if (task.IsReady())
+            {
+                task.GetMapTile().CreateUnityMesh(task.offsetX, task.offsetY);
+                readyTasks.Add(task);
+            }
+        }
 
-		foreach (TileTask task in pendingTasks)
-		{
-			if (task.IsReady())
-			{
-				task.GetMapTile().CreateUnityMesh(task.offsetX, task.offsetY);
-				readyTasks.Add(task);
-			}
-		}
-
-		foreach (TileTask readyTask in readyTasks)
-		{
-			pendingTasks.Remove(readyTask);
-		}
-	}
+        foreach (TileTask readyTask in readyTasks)
+        {
+            pendingTasks.Remove(readyTask);
+        }
+    }
 }

--- a/Assets/MeshData.cs
+++ b/Assets/MeshData.cs
@@ -4,25 +4,25 @@ using UnityEngine;
 
 public class MeshData
 {
-	public List<int> indices = new List<int>();
-	public List<Vector3> vertices = new List<Vector3>();
-	public List<Color> colors = new List<Color>();
+    public List<int> indices = new List<int>();
+    public List<Vector3> vertices = new List<Vector3>();
+    public List<Color> colors = new List<Color>();
 
-	public void FlipIndices()
-	{
-		indices.Reverse();
-	}
+    public void FlipIndices()
+    {
+        indices.Reverse();
+    }
 
-	public void Add(MeshData meshData)
-	{
-		int indexOffset = vertices.Count;
+    public void Add(MeshData meshData)
+    {
+        int indexOffset = vertices.Count;
 
-		for (int i = 0; i < meshData.indices.Count; ++i) 
-		{
-			indices.Add(indexOffset + meshData.indices[i]);
-		}
+        for (int i = 0; i < meshData.indices.Count; ++i)
+        {
+            indices.Add(indexOffset + meshData.indices[i]);
+        }
 
-		vertices.AddRange(meshData.vertices);
-		colors.AddRange(meshData.colors);
-	}
+        vertices.AddRange(meshData.vertices);
+        colors.AddRange(meshData.colors);
+    }
 }

--- a/Assets/TileTask.cs
+++ b/Assets/TileTask.cs
@@ -1,51 +1,50 @@
 ﻿using System;
 using System.Collections.Generic;
 using Mapzen;
-// TODO remove
-using UnityEngine;
 using Mapzen.VectorData;
 
-public class TileTask {
-	private TileAddress address;
-	private string response;
-	private MapTile tile;
-	private List<string> layers;
-	private bool ready;
+public class TileTask
+{
+    private TileAddress address;
+    private string response;
+    private MapTile tile;
+    private List<string> layers;
+    private bool ready;
 
-	// TODO: remove those offset once we have better tile placement
-	public float offsetX = 0.0f;
-	public float offsetY = 0.0f;
+    // TODO: remove those offset once we have better tile placement
+    public float offsetX = 0.0f;
+    public float offsetY = 0.0f;
 
-	public TileTask(TileAddress address, List<string> layers, string response, MapTile tile)
-	{
-		this.address = address;
-		this.response = response;
-		this.layers = layers;
-		this.tile = tile;
+    public TileTask(TileAddress address, List<string> layers, string response, MapTile tile)
+    {
+        this.address = address;
+        this.response = response;
+        this.layers = layers;
+        this.tile = tile;
 
-		ready = false;
-	}
+        ready = false;
+    }
 
-	public void Start()
-	{
-		var projection = GeoJSON.LocalCoordinateProjectionForTile(address);
+    public void Start()
+    {
+        var projection = GeoJSON.LocalCoordinateProjectionForTile(address);
 
-		// Parse the GeoJSON
-		var geoJson = new GeoJSON(response, projection);
+        // Parse the GeoJSON
+        var geoJson = new GeoJSON(response, projection);
 
-		// Tesselate the mesh
-		tile.BuildMesh(address.GetSizeMercatorMeters(), geoJson.GetLayersByName(layers));
+        // Tesselate the mesh
+        tile.BuildMesh(address.GetSizeMercatorMeters(), geoJson.GetLayersByName(layers));
 
-		ready = true;
-	}
+        ready = true;
+    }
 
-	public bool IsReady()
-	{
-		return ready;
-	}
+    public bool IsReady()
+    {
+        return ready;
+    }
 
-	public MapTile GetMapTile()
-	{
-		return tile;
-	}
+    public MapTile GetMapTile()
+    {
+        return tile;
+    }
 }

--- a/CodeFormatting.mdpolicy
+++ b/CodeFormatting.mdpolicy
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PolicySet name="CodeFormatting">
+  <TextStylePolicy inheritsSet="VisualStudio" inheritsScope="text/plain" scope="text/plain">
+    <FileWidth>120</FileWidth>
+    <NoTabsAfterNonTabs>True</NoTabsAfterNonTabs>
+  </TextStylePolicy>
+  <VersionControlPolicy inheritsSet="Mono" />
+  <CSharpFormattingPolicy inheritsSet="Mono" inheritsScope="text/x-csharp" scope="text/x-csharp">
+    <IndentSwitchBody>True</IndentSwitchBody>
+    <IndentBlocksInsideExpressions>True</IndentBlocksInsideExpressions>
+    <AnonymousMethodBraceStyle>NextLine</AnonymousMethodBraceStyle>
+    <PropertyBraceStyle>NextLine</PropertyBraceStyle>
+    <PropertyGetBraceStyle>NextLine</PropertyGetBraceStyle>
+    <PropertySetBraceStyle>NextLine</PropertySetBraceStyle>
+    <EventBraceStyle>NextLine</EventBraceStyle>
+    <EventAddBraceStyle>NextLine</EventAddBraceStyle>
+    <EventRemoveBraceStyle>NextLine</EventRemoveBraceStyle>
+    <StatementBraceStyle>NextLine</StatementBraceStyle>
+    <ElseNewLinePlacement>NewLine</ElseNewLinePlacement>
+    <CatchNewLinePlacement>NewLine</CatchNewLinePlacement>
+    <FinallyNewLinePlacement>NewLine</FinallyNewLinePlacement>
+    <WhileNewLinePlacement>DoNotCare</WhileNewLinePlacement>
+    <ArrayInitializerWrapping>DoNotChange</ArrayInitializerWrapping>
+    <ArrayInitializerBraceStyle>NextLine</ArrayInitializerBraceStyle>
+    <BeforeMethodDeclarationParentheses>False</BeforeMethodDeclarationParentheses>
+    <BeforeMethodCallParentheses>False</BeforeMethodCallParentheses>
+    <BeforeConstructorDeclarationParentheses>False</BeforeConstructorDeclarationParentheses>
+    <NewLineBeforeConstructorInitializerColon>NewLine</NewLineBeforeConstructorInitializerColon>
+    <NewLineAfterConstructorInitializerColon>SameLine</NewLineAfterConstructorInitializerColon>
+    <BeforeDelegateDeclarationParentheses>False</BeforeDelegateDeclarationParentheses>
+    <NewParentheses>False</NewParentheses>
+    <SpacesBeforeBrackets>False</SpacesBeforeBrackets>
+  </CSharpFormattingPolicy>
+  <NameConventionPolicy>
+    <Rules>
+      <NamingRule>
+        <Name>Namespaces</Name>
+        <AffectedEntity>Namespace</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Types</Name>
+        <AffectedEntity>Class, Struct, Enum, Delegate</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Interfaces</Name>
+        <RequiredPrefixes>
+          <String>I</String>
+        </RequiredPrefixes>
+        <AffectedEntity>Interface</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Attributes</Name>
+        <RequiredSuffixes>
+          <String>Attribute</String>
+        </RequiredSuffixes>
+        <AffectedEntity>CustomAttributes</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Event Arguments</Name>
+        <RequiredSuffixes>
+          <String>EventArgs</String>
+        </RequiredSuffixes>
+        <AffectedEntity>CustomEventArgs</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Exceptions</Name>
+        <RequiredSuffixes>
+          <String>Exception</String>
+        </RequiredSuffixes>
+        <AffectedEntity>CustomExceptions</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Methods</Name>
+        <AffectedEntity>Methods</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Static Readonly Fields</Name>
+        <AffectedEntity>ReadonlyField</AffectedEntity>
+        <VisibilityMask>Internal, Protected, Public</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>False</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Fields (Non Private)</Name>
+        <AffectedEntity>Field</AffectedEntity>
+        <VisibilityMask>Internal, Protected, Public</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>ReadOnly Fields (Non Private)</Name>
+        <AffectedEntity>ReadonlyField</AffectedEntity>
+        <VisibilityMask>Internal, Protected, Public</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>False</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Fields (Private)</Name>
+        <AllowedPrefixes>
+          <String>_</String>
+          <String>m_</String>
+        </AllowedPrefixes>
+        <AffectedEntity>Field, ReadonlyField</AffectedEntity>
+        <VisibilityMask>Private</VisibilityMask>
+        <NamingStyle>CamelCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>False</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Static Fields (Private)</Name>
+        <AffectedEntity>Field</AffectedEntity>
+        <VisibilityMask>Private</VisibilityMask>
+        <NamingStyle>CamelCase</NamingStyle>
+        <IncludeInstanceMembers>False</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>ReadOnly Fields (Private)</Name>
+        <AllowedPrefixes>
+          <String>_</String>
+          <String>m_</String>
+        </AllowedPrefixes>
+        <AffectedEntity>ReadonlyField</AffectedEntity>
+        <VisibilityMask>Private</VisibilityMask>
+        <NamingStyle>CamelCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>False</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Constant Fields</Name>
+        <AffectedEntity>ConstantField</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Properties</Name>
+        <AffectedEntity>Property</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Events</Name>
+        <AffectedEntity>Event</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Enum Members</Name>
+        <AffectedEntity>EnumMember</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Parameters</Name>
+        <AffectedEntity>Parameter</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>CamelCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+      <NamingRule>
+        <Name>Type Parameters</Name>
+        <RequiredPrefixes>
+          <String>T</String>
+        </RequiredPrefixes>
+        <AffectedEntity>TypeParameter</AffectedEntity>
+        <VisibilityMask>VisibilityMask</VisibilityMask>
+        <NamingStyle>PascalCase</NamingStyle>
+        <IncludeInstanceMembers>True</IncludeInstanceMembers>
+        <IncludeStaticEntities>True</IncludeStaticEntities>
+      </NamingRule>
+    </Rules>
+  </NameConventionPolicy>
+  <XmlFormattingPolicy inheritsSet="Mono" inheritsScope="application/xml" scope="application/xml" />
+  <TextStylePolicy inheritsSet="VisualStudio" inheritsScope="text/plain" scope="application/xml">
+    <FileWidth>120</FileWidth>
+    <NoTabsAfterNonTabs>True</NoTabsAfterNonTabs>
+  </TextStylePolicy>
+  <TextStylePolicy inheritsSet="VisualStudio" inheritsScope="text/plain" scope="text/x-csharp">
+    <FileWidth>120</FileWidth>
+    <NoTabsAfterNonTabs>True</NoTabsAfterNonTabs>
+  </TextStylePolicy>
+</PolicySet>


### PR DESCRIPTION
In MonoDevelop: 
Project -> Apply Policy -> Apply policies from file

Then load the policy for the code styling of the project
[CodeFormatting.mdpolicy.zip](https://github.com/tangrams/tangram-unity/files/1026223/CodeFormatting.mdpolicy.zip)

The code styling is inherited from the settings "Visual Studio" within MonoDevelop with minor custom changes relating to tabs.

Settings are set to the following:
![screen shot 2017-05-24 at 12 11 51 pm](https://cloud.githubusercontent.com/assets/7061573/26413503/3721fcfc-407a-11e7-8ca3-ee1313d83bb3.png)

If anyone has specific preferences we should update it and apply them on this branch.