### PR TITLE
Add basic feature filtering

### DIFF
--- a/Assets/MapTile.cs
+++ b/Assets/MapTile.cs
@@ -24,9 +24,9 @@ public class MapTile : MonoBehaviour
 
         foreach (var layer in layers)
         {
-            Color color = layerColors[layer.name];
+            Color color = layerColors[layer.Name];
 
-            foreach (var feature in layer.features)
+            foreach (var feature in layer.Features)
             {
                 // TODO: use extrusion scale and minHeight as options
                 float height = 0.0f;

--- a/Assets/MapTile.cs
+++ b/Assets/MapTile.cs
@@ -19,7 +19,7 @@ public class MapTile : MonoBehaviour
         var waterLayerFilter = new FeatureFilter().TakeAllFromCollections("water");
 
         // Filter that accepts all features in the "buildings" layer with a "height" property.
-        var buildingExtrusionFilter = new FeatureFilter().TakeAllFromCollections("buildings").Where(FeatureMatcher.HasProperty("height"));
+        var buildingExtrusionFilter = new FeatureFilter().TakeAllFromCollections("buildings").Where(FeatureMatcher.HasPropertyInRange("height", null, 30));
 
         // Filter that accepts all features in the "earth" or "landuse" layers.
         var landLayerFilter = new FeatureFilter().TakeAllFromCollections("earth", "landuse");
@@ -59,10 +59,11 @@ public class MapTile : MonoBehaviour
                     float height = 0.0f;
                     float minHeight = 0.0f;
 
-                    JSONNode heightNode;
-                    if (feature.TryGetProperty("height", out heightNode))
+                    object heightValue;
+                    if (feature.TryGetProperty("height", out heightValue) && heightValue is double)
                     {
-                        height = heightNode * inverseTileScale;
+                        // For some reason we can't cast heightValue straight to float.
+                        height = (float)((double)heightValue * inverseTileScale);
                     }
 
                     if (feature.geometry.type == GeometryType.Polygon)

--- a/Assets/MapTile.cs
+++ b/Assets/MapTile.cs
@@ -1,52 +1,78 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using Mapzen.VectorData;
+using Mapzen.VectorData.Filters;
 using SimpleJSON;
 
-[RequireComponent(typeof(MeshFilter))]
+[RequireComponent(typeof(MeshFilter), typeof(MeshRenderer))]
 public class MapTile : MonoBehaviour
 {
-    private MeshData meshData;
+    private MeshData meshData = new MeshData();
 
-    private Dictionary<String, Color> layerColors = new Dictionary<String, Color>
+    private Dictionary<IFeatureFilter, Material> featureStyling = new Dictionary<IFeatureFilter, Material>();
+
+    public void Start()
     {
-        { "water", Color.blue },
-        { "earth", Color.green },
-        { "roads", Color.gray },
-        { "buildings", Color.black },
-    };
+        // Filter that accepts all features in the "water" layer.
+        var waterLayerFilter = new FeatureFilter().TakeAllFromCollections("water");
+
+        // Filter that accepts all features in the "buildings" layer with a "height" property.
+        var buildingExtrusionFilter = new FeatureFilter().TakeAllFromCollections("buildings").Where(FeatureMatcher.HasProperty("height"));
+
+        // Filter that accepts all features in the "earth" or "landuse" layers.
+        var landLayerFilter = new FeatureFilter().TakeAllFromCollections("earth", "landuse");
+
+        var baseMaterial = GetComponent<MeshRenderer>().material;
+
+        var waterMaterial = new Material(baseMaterial);
+        waterMaterial.color = Color.blue;
+
+        var buildingMaterial = new Material(baseMaterial);
+        buildingMaterial.color = Color.gray;
+
+        var landMaterial = new Material(baseMaterial);
+        landMaterial.color = Color.green;
+
+        featureStyling.Add(waterLayerFilter, waterMaterial);
+        featureStyling.Add(buildingExtrusionFilter, buildingMaterial);
+        featureStyling.Add(landLayerFilter, landMaterial);
+    }
 
     public void BuildMesh(double tileScale, List<FeatureCollection> layers)
     {
-        meshData = new MeshData();
         float inverseTileScale = 1.0f / (float)tileScale;
 
-        foreach (var layer in layers)
+        foreach (var entry in featureStyling)
         {
-            Color color = layerColors[layer.Name];
+            var filter = entry.Key;
+            var material = entry.Value;
 
-            foreach (var feature in layer.Features)
+            foreach (var layer in layers)
             {
-                // TODO: use extrusion scale and minHeight as options
-                float height = 0.0f;
-                float minHeight = 0.0f;
+                var filteredFeatures = filter.Filter(layer);
 
-                JSONNode heightNode;
-                if (feature.TryGetProperty("height", out heightNode))
+                foreach (var feature in filteredFeatures)
                 {
-                    height = heightNode * inverseTileScale;
-                }
+                    // TODO: use extrusion scale and minHeight as options
+                    float height = 0.0f;
+                    float minHeight = 0.0f;
 
-                if (feature.geometry.type == GeometryType.Polygon)
-                {
-                    var polygonMeshData = Builder.TesselatePolygon(feature.geometry, color, height);
-                    meshData.Add(polygonMeshData);
-
-                    if (height > 0.0f)
+                    JSONNode heightNode;
+                    if (feature.TryGetProperty("height", out heightNode))
                     {
-                        var extrusionMeshData = Builder.TesselatePolygonExtrusion(feature.geometry, color, minHeight, height);
-                        meshData.Add(extrusionMeshData);
+                        height = heightNode * inverseTileScale;
+                    }
+
+                    if (feature.geometry.type == GeometryType.Polygon)
+                    {
+                        Builder.TesselatePolygon(meshData, feature.geometry, material, height);
+
+                        if (height > 0.0f)
+                        {
+                            Builder.TesselatePolygonExtrusion(meshData, feature.geometry, material, minHeight, height);
+                        }
                     }
                 }
             }
@@ -58,14 +84,21 @@ public class MapTile : MonoBehaviour
     public void CreateUnityMesh(float offsetX, float offsetY)
     {
         var mesh = new Mesh();
-        GetComponent<MeshFilter>().mesh = mesh;
 
-        mesh.vertices = meshData.vertices.ToArray();
-        mesh.triangles = meshData.indices.ToArray();
-        mesh.colors = meshData.colors.ToArray();
+        mesh.SetVertices(meshData.Vertices);
+
+        mesh.subMeshCount = meshData.Submeshes.Count;
+        for (int i = 0; i < meshData.Submeshes.Count; i++)
+        {
+            mesh.SetTriangles(meshData.Submeshes[i].Indices, i);
+        }
+
         mesh.RecalculateNormals();
 
         transform.Translate(new Vector3(offsetX, 0.0f, offsetY));
+
+        GetComponent<MeshFilter>().mesh = mesh;
+        GetComponent<MeshRenderer>().materials = meshData.Submeshes.Select(s => s.Material).ToArray();
     }
 
     public void Update()

--- a/Assets/Mapzen/VectorData/Feature.cs
+++ b/Assets/Mapzen/VectorData/Feature.cs
@@ -14,19 +14,18 @@ namespace Mapzen.VectorData
 
         public Dictionary<string, object> properties { get; set; }
 
-        public bool TryGetProperty<N>(string propertyKey, out N node)
+        public bool TryGetProperty(string key, out object value)
         {
             object propertyValue;
-            if (properties.TryGetValue(propertyKey, out propertyValue))
+            if (properties.TryGetValue(key, out propertyValue))
             {
-                var propertyNode = (N)propertyValue;
-                if (propertyNode != null)
+                if (propertyValue != null)
                 {
-                    node = propertyNode;
+                    value = propertyValue;
                     return true;
                 }
             }
-            node = default(N);
+            value = null;
             return false;
         }
     }

--- a/Assets/Mapzen/VectorData/FeatureCollection.cs
+++ b/Assets/Mapzen/VectorData/FeatureCollection.cs
@@ -6,11 +6,11 @@ namespace Mapzen.VectorData
     {
         public FeatureCollection(string name = "")
         {
-            this.name = name;
-            this.features = new List<Feature>();
+            Name = name;
+            Features = new List<Feature>();
         }
 
-        public string name;
-        public List<Feature> features;
+        public string Name;
+        public List<Feature> Features;
     }
 }

--- a/Assets/Mapzen/VectorData/Filters.meta
+++ b/Assets/Mapzen/VectorData/Filters.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9d2635cb6f1e5f14fbb49f77b1ade43b
+folderAsset: yes
+timeCreated: 1495654846
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mapzen/VectorData/Filters/CompoundFeatureMatcher.cs
+++ b/Assets/Mapzen/VectorData/Filters/CompoundFeatureMatcher.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Mapzen.VectorData.Filters
+{
+    public class CompoundFeatureMatcher : IFeatureMatcher
+    {
+        public enum Operator
+        {
+            Any,
+            All,
+            None,
+        }
+
+        public List<IFeatureMatcher> Matchers { get; set; }
+
+        public Operator Type { get; set; }
+
+        public bool MatchesFeature(Feature feature)
+        {
+            switch (Type)
+            {
+                case Operator.Any:
+                    return Matchers.Any(m => m.MatchesFeature(feature));
+                case Operator.All:
+                    return Matchers.All(m => m.MatchesFeature(feature));
+                case Operator.None:
+                    return !Matchers.Any(m => m.MatchesFeature(feature));
+                default:
+                    return false;
+            }
+        }
+    }
+}
+

--- a/Assets/Mapzen/VectorData/Filters/CompoundFeatureMatcher.cs.meta
+++ b/Assets/Mapzen/VectorData/Filters/CompoundFeatureMatcher.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f9c16e956a8b4438fa5cef0a1f0ccba1
+timeCreated: 1495773131
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mapzen/VectorData/Filters/FeatureFilter.cs
+++ b/Assets/Mapzen/VectorData/Filters/FeatureFilter.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Mapzen.VectorData.Filters
+{
+    public class FeatureFilter : IFeatureFilter
+    {
+        public IFeatureMatcher Matcher { get; set; }
+
+        public List<string> CollectionNameSet { get; set; }
+
+        public FeatureFilter()
+        {
+            Matcher = new FeatureMatcher();
+            CollectionNameSet = new List<string>();
+        }
+
+        public virtual IEnumerable<Feature> Filter(FeatureCollection collection)
+        {
+            if (CollectionNameSet.Contains(collection.Name))
+            {
+                return collection.Features.Where(Matcher.MatchesFeature);
+            }
+            return Enumerable.Empty<Feature>();
+        }
+
+        public FeatureFilter TakeAllFromCollections(params string[] collectionNames)
+        {
+            CollectionNameSet.AddRange(collectionNames);
+            return this;
+        }
+
+        public FeatureFilter Where(IFeatureMatcher predicate)
+        {
+            Matcher = predicate;
+            return this;
+        }
+    }
+}

--- a/Assets/Mapzen/VectorData/Filters/FeatureFilter.cs.meta
+++ b/Assets/Mapzen/VectorData/Filters/FeatureFilter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9859d8473f63e4f66922dfa78a22e70c
+timeCreated: 1496276574
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mapzen/VectorData/Filters/FeatureMatcher.cs
+++ b/Assets/Mapzen/VectorData/Filters/FeatureMatcher.cs
@@ -54,7 +54,7 @@ namespace Mapzen.VectorData.Filters
             };
         }
 
-        public static IFeatureMatcher HasPropertyInRange(string property, IComparable min, IComparable max)
+        public static IFeatureMatcher HasPropertyInRange(string property, double? min, double? max)
         {
             return new PropertyRangeFeatureMatcher
             {

--- a/Assets/Mapzen/VectorData/Filters/FeatureMatcher.cs
+++ b/Assets/Mapzen/VectorData/Filters/FeatureMatcher.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Linq;
+
+namespace Mapzen.VectorData.Filters
+{
+    public class FeatureMatcher : IFeatureMatcher
+    {
+        public virtual bool MatchesFeature(Feature feature)
+        {
+            return true;
+        }
+
+        public static IFeatureMatcher AnyOf(params IFeatureMatcher[] predicates)
+        {
+            return new CompoundFeatureMatcher
+            {
+                Type = CompoundFeatureMatcher.Operator.Any,
+                Matchers = predicates.ToList(),
+            };
+        }
+
+        public static IFeatureMatcher AllOf(params IFeatureMatcher[] predicates)
+        {
+            return new CompoundFeatureMatcher
+            {
+                Type = CompoundFeatureMatcher.Operator.All,
+                Matchers = predicates.ToList(),
+            };
+        }
+
+        public static IFeatureMatcher NoneOf(params IFeatureMatcher[] predicates)
+        {
+            return new CompoundFeatureMatcher
+            {
+                Type = CompoundFeatureMatcher.Operator.None,
+                Matchers = predicates.ToList(),
+            };
+        }
+
+        public static IFeatureMatcher HasProperty(string property)
+        {
+            return new PropertyFeatureMatcher
+            {
+                Key = property,
+            };
+        }
+
+        public static IFeatureMatcher HasPropertyWithValue(string property, params object[] values)
+        {
+            return new PropertyValueFeatureMatcher
+            {
+                Key = property,
+                ValueSet = values.ToList(),
+            };
+        }
+
+        public static IFeatureMatcher HasPropertyInRange(string property, IComparable min, IComparable max)
+        {
+            return new PropertyRangeFeatureMatcher
+            {
+                Key = property,
+                Min = min,
+                Max = max,
+            };
+        }
+    }
+}
+

--- a/Assets/Mapzen/VectorData/Filters/FeatureMatcher.cs.meta
+++ b/Assets/Mapzen/VectorData/Filters/FeatureMatcher.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 3117395e4f2768140b9d3dfa4262ece7
+timeCreated: 1496379894
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mapzen/VectorData/Filters/IFeatureFilter.cs
+++ b/Assets/Mapzen/VectorData/Filters/IFeatureFilter.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace Mapzen.VectorData.Filters
+{
+	public interface IFeatureFilter
+	{
+		IEnumerable<Feature> Filter(FeatureCollection collection);
+	}
+}

--- a/Assets/Mapzen/VectorData/Filters/IFeatureFilter.cs.meta
+++ b/Assets/Mapzen/VectorData/Filters/IFeatureFilter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: bb4e26c5995514101965d8167170884f
+timeCreated: 1495765883
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mapzen/VectorData/Filters/IFeatureMatcher.cs
+++ b/Assets/Mapzen/VectorData/Filters/IFeatureMatcher.cs
@@ -1,0 +1,7 @@
+﻿namespace Mapzen.VectorData.Filters
+{
+	public interface IFeatureMatcher
+	{
+		bool MatchesFeature(Feature feature);
+	}
+}

--- a/Assets/Mapzen/VectorData/Filters/IFeatureMatcher.cs.meta
+++ b/Assets/Mapzen/VectorData/Filters/IFeatureMatcher.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 61d7f078d3eb74e0ea582845fbb43935
+timeCreated: 1495765883
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mapzen/VectorData/Filters/PropertyFeatureMatcher.cs
+++ b/Assets/Mapzen/VectorData/Filters/PropertyFeatureMatcher.cs
@@ -1,0 +1,22 @@
+﻿namespace Mapzen.VectorData.Filters
+{
+    public class PropertyFeatureMatcher : IFeatureMatcher
+    {
+        public string Key { get; set; }
+
+        public bool MatchesFeature(Feature feature)
+        {
+            object property;
+            if (feature.properties.TryGetValue(Key, out property))
+            {
+                return MatchesProperty(property);
+            }
+            return false;
+        }
+
+        protected virtual bool MatchesProperty(object property)
+        {
+            return true;
+        }
+    }
+}

--- a/Assets/Mapzen/VectorData/Filters/PropertyFeatureMatcher.cs.meta
+++ b/Assets/Mapzen/VectorData/Filters/PropertyFeatureMatcher.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0403e2c2a2ece4a4ea5be1d3b568cbe0
+timeCreated: 1496276574
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mapzen/VectorData/Filters/PropertyRangeFeatureMatcher.cs
+++ b/Assets/Mapzen/VectorData/Filters/PropertyRangeFeatureMatcher.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace Mapzen.VectorData.Filters
+{
+    public class PropertyRangeFeatureMatcher : PropertyFeatureMatcher
+    {
+        public IComparable Min { get; set; }
+
+        public IComparable Max { get; set; }
+
+        protected override bool MatchesProperty(object property)
+        {
+            // If a Min value is set and the property value precedes it, return false.
+            if (Min != null && Min.CompareTo(property) > 0)
+            {
+                return false;
+            }
+            // If a Max value is set and it precedes the property value, return false.
+            if (Max != null && Max.CompareTo(property) <= 0)
+            {
+                return false;
+            }
+            // Otherwise, return true.
+            return true;
+        }
+    }
+}

--- a/Assets/Mapzen/VectorData/Filters/PropertyRangeFeatureMatcher.cs
+++ b/Assets/Mapzen/VectorData/Filters/PropertyRangeFeatureMatcher.cs
@@ -4,19 +4,24 @@ namespace Mapzen.VectorData.Filters
 {
     public class PropertyRangeFeatureMatcher : PropertyFeatureMatcher
     {
-        public IComparable Min { get; set; }
+        public double? Min { get; set; }
 
-        public IComparable Max { get; set; }
+        public double? Max { get; set; }
 
         protected override bool MatchesProperty(object property)
         {
+            var number = property as double?;
+            if (number == null)
+            {
+                return false;
+            }
             // If a Min value is set and the property value precedes it, return false.
-            if (Min != null && Min.CompareTo(property) > 0)
+            if (Min != null && number < Min)
             {
                 return false;
             }
             // If a Max value is set and it precedes the property value, return false.
-            if (Max != null && Max.CompareTo(property) <= 0)
+            if (Max != null && number >= Max)
             {
                 return false;
             }

--- a/Assets/Mapzen/VectorData/Filters/PropertyRangeFeatureMatcher.cs.meta
+++ b/Assets/Mapzen/VectorData/Filters/PropertyRangeFeatureMatcher.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 67847ec510398462b9c1fbf657467050
+timeCreated: 1495661631
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mapzen/VectorData/Filters/PropertyRegexFeatureMatcher.cs
+++ b/Assets/Mapzen/VectorData/Filters/PropertyRegexFeatureMatcher.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Text.RegularExpressions;
+
+namespace Mapzen.VectorData.Filters
+{
+    public class PropertyRegexFeatureMatcher : PropertyFeatureMatcher
+    {
+        public Regex Regex { get; set; }
+
+        protected override bool MatchesProperty(object property)
+        {
+            string s = property as string;
+            if (s != null)
+            {
+                return Regex.IsMatch(s);
+            }
+            return false;
+        }
+    }
+}

--- a/Assets/Mapzen/VectorData/Filters/PropertyRegexFeatureMatcher.cs.meta
+++ b/Assets/Mapzen/VectorData/Filters/PropertyRegexFeatureMatcher.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2a279433f246c45eaabbb7b96075e6fb
+timeCreated: 1496276574
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mapzen/VectorData/Filters/PropertyValueFeatureMatcher.cs
+++ b/Assets/Mapzen/VectorData/Filters/PropertyValueFeatureMatcher.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace Mapzen.VectorData.Filters
+{
+    public class PropertyValueFeatureMatcher : PropertyFeatureMatcher
+    {
+        public List<object> ValueSet { get; set; }
+
+        protected override bool MatchesProperty(object property)
+        {
+            return ValueSet.Contains(property);
+        }
+    }
+}

--- a/Assets/Mapzen/VectorData/Filters/PropertyValueFeatureMatcher.cs.meta
+++ b/Assets/Mapzen/VectorData/Filters/PropertyValueFeatureMatcher.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9e19b8d988633674f8bd8b49e000316f
+timeCreated: 1495656130
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mapzen/VectorData/GeoJSON.cs
+++ b/Assets/Mapzen/VectorData/GeoJSON.cs
@@ -69,7 +69,7 @@ namespace Mapzen
 
             foreach (JSONNode feature in features.Children)
             {
-                layer.features.Add(GetFeature(feature));
+                layer.Features.Add(GetFeature(feature));
             }
 
             return layer;

--- a/Assets/Mapzen/VectorData/GeoJSON.cs
+++ b/Assets/Mapzen/VectorData/GeoJSON.cs
@@ -84,8 +84,16 @@ namespace Mapzen
             {
                 foreach (KeyValuePair<string, JSONNode> property in propertiesNode.AsObject)
                 {
-                    // TODO: Define more strict typing on property values.
-                    feature.properties.Add(property.Key, property.Value);
+                    // A property value is an object, but is only permitted to be a boolean, a double, or a string.
+                    object value;
+                    switch (property.Value.Tag)
+                    {
+                        case JSONNodeType.Boolean: value = property.Value.AsBool; break;
+                        case JSONNodeType.Number: value = property.Value.AsDouble; break;
+                        case JSONNodeType.String: value = property.Value.Value; break;
+                        default: value = null; break;
+                    }
+                    feature.properties.Add(property.Key, value);
                 }
             }
 

--- a/Assets/MapzenMap.cs
+++ b/Assets/MapzenMap.cs
@@ -50,7 +50,7 @@ public class MapzenMap : MonoBehaviour
                         return;
                     }
 
-                    Debug.Log("Response: " + response);
+                    // Debug.Log("Response: " + response);
 
                     // Adding a tile object to the scene
                     GameObject tilePrefab = Resources.Load("Tile") as GameObject;

--- a/Assets/MeshData.cs
+++ b/Assets/MeshData.cs
@@ -4,25 +4,53 @@ using UnityEngine;
 
 public class MeshData
 {
-    public List<int> indices = new List<int>();
-    public List<Vector3> vertices = new List<Vector3>();
-    public List<Color> colors = new List<Color>();
+    public class Submesh
+    {
+        public List<int> Indices;
+        public Material Material;
+    }
+
+    public List<Vector3> Vertices { get; }
+    public List<Submesh> Submeshes { get; }
+
+    public MeshData()
+    {
+        Vertices = new List<Vector3>();
+        Submeshes = new List<Submesh>();
+    }
+
+    public void AddElements(IEnumerable<Vector3> vertices, IEnumerable<int> indices, Material material)
+    {
+        int offset = Vertices.Count;
+        Vertices.AddRange(vertices);
+
+        // Find a submesh with this material, or create a new one.
+        Submesh submesh = null;
+        foreach (var s in Submeshes)
+        {
+            if (s.Material == material)
+            {
+                submesh = s;
+                break;
+            }
+        }
+        if (submesh == null)
+        {
+            submesh = new Submesh { Indices = new List<int>(), Material = material };
+            Submeshes.Add(submesh);
+        }
+
+        foreach (var index in indices)
+        {
+            submesh.Indices.Add(index + offset);
+        }
+    }
 
     public void FlipIndices()
     {
-        indices.Reverse();
-    }
-
-    public void Add(MeshData meshData)
-    {
-        int indexOffset = vertices.Count;
-
-        for (int i = 0; i < meshData.indices.Count; ++i)
+        foreach (var submesh in Submeshes)
         {
-            indices.Add(indexOffset + meshData.indices[i]);
+            submesh.Indices.Reverse();
         }
-
-        vertices.AddRange(meshData.vertices);
-        colors.AddRange(meshData.colors);
     }
 }


### PR DESCRIPTION
Let's consider this a first pass. There's a lot more to do here, both to refine the classes that are here and to add an interface for creating filters in the Unity editor, but there's enough code here that I wanted to start merging it back to master.

`PropertyRangeMatcher` currently throws an exception when the property in the tile data isn't the same type as the range limits (which is very frequently), so I don't recommend using it yet. 