### PR TITLE
Tile adress range from an area defined with Lat/Lon and zoom level

### DIFF
--- a/Assets/Builder.cs
+++ b/Assets/Builder.cs
@@ -68,11 +68,11 @@ public class Builder
                     vertices.Add(new Vector3(p0.x, minHeight, p0.y));
                     vertices.Add(new Vector3(p1.x, minHeight, p1.y));
 
-                    indices.Add(indexOffset + 2);
+                    indices.Add(indexOffset + 1);
                     indices.Add(indexOffset + 3);
-                    indices.Add(indexOffset + 1);
                     indices.Add(indexOffset + 2);
                     indices.Add(indexOffset + 1);
+                    indices.Add(indexOffset + 2);
                     indices.Add(indexOffset + 0);
 
                     indexOffset += 4;

--- a/Assets/DefaultScene.unity
+++ b/Assets/DefaultScene.unity
@@ -135,12 +135,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: f99f332e167bc4c5cb799d5f5171e0b0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  TileX: 19293
-  TileY: 24640
-  TileZ: 16
-  TileRangeX: 4
-  TileRangeY: 4
   ApiKey: vector-tiles-tyHL4AY
+  Area:
+    min:
+      longitude: -74.019463
+      latitude: 40.700446
+    max:
+      longitude: -73.998306
+      latitude: 40.716939
+    zoom: 16
 --- !u!4 &349009245
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Mapzen/Geo.cs
+++ b/Assets/Mapzen/Geo.cs
@@ -11,7 +11,7 @@ namespace Mapzen
         public static MercatorMeters Project(LngLat lngLat)
         {
             double x = lngLat.longitude * EarthHalfCircumferenceMeters / 180.0 + EarthHalfCircumferenceMeters;
-            double y = -Math.Log(Math.Tan(0.25 * Math.PI + lngLat.latitude * Math.PI / 360.0)) * EarthRadiusMeters + EarthHalfCircumferenceMeters;
+            double y = Math.Log(Math.Tan(0.25 * Math.PI + lngLat.latitude * Math.PI / 360.0)) * EarthRadiusMeters + EarthHalfCircumferenceMeters;
             return new MercatorMeters(x, y);
         }
 

--- a/Assets/Mapzen/Geo.cs
+++ b/Assets/Mapzen/Geo.cs
@@ -7,11 +7,12 @@ namespace Mapzen
         public static readonly double EarthRadiusMeters = 6378137.0;
         public static readonly double EarthCircumferenceMeters = EarthRadiusMeters * Math.PI * 2.0;
         public static readonly double EarthHalfCircumferenceMeters = EarthRadiusMeters * Math.PI;
+        public static readonly int TilePixelSize = 256;
 
         public static MercatorMeters Project(LngLat lngLat)
         {
             double x = lngLat.longitude * EarthHalfCircumferenceMeters / 180.0 + EarthHalfCircumferenceMeters;
-            double y = Math.Log(Math.Tan(0.25 * Math.PI + lngLat.latitude * Math.PI / 360.0)) * EarthRadiusMeters + EarthHalfCircumferenceMeters;
+            double y = -Math.Log(Math.Tan(0.25 * Math.PI + lngLat.latitude * Math.PI / 360.0)) * EarthRadiusMeters + EarthHalfCircumferenceMeters;
             return new MercatorMeters(x, y);
         }
 

--- a/Assets/Mapzen/LngLat.cs
+++ b/Assets/Mapzen/LngLat.cs
@@ -2,6 +2,7 @@
 
 namespace Mapzen
 {
+    [System.Serializable]
     public struct LngLat
     {
         public LngLat(double lng, double lat)

--- a/Assets/Mapzen/TileAddress.cs
+++ b/Assets/Mapzen/TileAddress.cs
@@ -42,7 +42,7 @@ namespace Mapzen
         public MercatorMeters GetOriginMercatorMeters()
         {
             double metersPerTile = GetSizeMercatorMeters();
-            return new MercatorMeters(x * metersPerTile, y * metersPerTile);
+            return new MercatorMeters(x * metersPerTile, Geo.EarthCircumferenceMeters - y * metersPerTile);
         }
 
         public int CompareTo(object obj)

--- a/Assets/Mapzen/TileAddress.cs
+++ b/Assets/Mapzen/TileAddress.cs
@@ -12,9 +12,9 @@ namespace Mapzen
             this.z = z;
         }
 
-        public static TileAddress FromLngLat(LngLat lngLat, int zoom, int pixelTileSize)
+        public static TileAddress FromLngLat(LngLat lngLat, int zoom)
         {
-            double tileResolution = Geo.EarthCircumferenceMeters / pixelTileSize;
+            double tileResolution = Geo.EarthCircumferenceMeters / Geo.TilePixelSize;
             double tileSize = tileResolution / (1 << zoom);
 
             MercatorMeters meters = Geo.Project(lngLat);
@@ -22,10 +22,10 @@ namespace Mapzen
             double px = meters.x / tileSize;
             double py = meters.y / tileSize;
 
-            int tileX = (int)(Math.Ceiling(px / pixelTileSize) - 1);
-            int tileY = (int)(Math.Ceiling(py / pixelTileSize) - 1);
+            int tileX = (int)(Math.Ceiling(px / Geo.TilePixelSize) - 1);
+            int tileY = (int)(Math.Ceiling(py / Geo.TilePixelSize) - 1);
 
-            return new TileAddress(tileX, ((1 << zoom) - 1) - tileY, zoom);
+            return new TileAddress(tileX, tileY, zoom);
         }
 
         public readonly int x;
@@ -58,7 +58,7 @@ namespace Mapzen
         public MercatorMeters GetOriginMercatorMeters()
         {
             double metersPerTile = GetSizeMercatorMeters();
-            return new MercatorMeters(x * metersPerTile, Geo.EarthCircumferenceMeters - y * metersPerTile);
+            return new MercatorMeters(x * metersPerTile, y * metersPerTile);
         }
 
         public int CompareTo(object obj)

--- a/Assets/Mapzen/TileAddress.cs
+++ b/Assets/Mapzen/TileAddress.cs
@@ -6,9 +6,8 @@ namespace Mapzen
     {
         public TileAddress(int x, int y, int z)
         {
-            int max = 1 << z;
-            this.x = x % max;
-            this.y = y % max;
+            this.x = x;
+            this.y = y;
             this.z = z;
         }
 
@@ -27,6 +26,22 @@ namespace Mapzen
         public readonly int x;
         public readonly int y;
         public readonly int z;
+
+        public TileAddress Wrapped()
+        {
+            int max = 1 << z;
+            int tileAddressX = x % max;
+            int tileAddressY = y % max;
+            if (tileAddressX < 0)
+            {
+                tileAddressX += max;
+            }
+            if (tileAddressY < 0)
+            {
+                tileAddressY += max;
+            }
+            return new TileAddress(tileAddressX, tileAddressY, this.z);
+        }
 
         public TileAddress GetParent()
         {

--- a/Assets/Mapzen/TileAddress.cs
+++ b/Assets/Mapzen/TileAddress.cs
@@ -12,6 +12,22 @@ namespace Mapzen
             this.z = z;
         }
 
+        public static TileAddress FromLngLat(LngLat lngLat, int zoom, int pixelTileSize)
+        {
+            double tileResolution = Geo.EarthCircumferenceMeters / pixelTileSize;
+            double tileSize = tileResolution / (1 << zoom);
+
+            MercatorMeters meters = Geo.Project(lngLat);
+
+            double px = meters.x / tileSize;
+            double py = meters.y / tileSize;
+
+            int tileX = (int)(Math.Ceiling(px / pixelTileSize) - 1);
+            int tileY = (int)(Math.Ceiling(py / pixelTileSize) - 1);
+
+            return new TileAddress(tileX, ((1 << zoom) - 1) - tileY, zoom);
+        }
+
         public readonly int x;
         public readonly int y;
         public readonly int z;

--- a/Assets/Mapzen/TileAddress.cs
+++ b/Assets/Mapzen/TileAddress.cs
@@ -18,11 +18,8 @@ namespace Mapzen
 
             MercatorMeters meters = Geo.Project(lngLat);
 
-            double px = meters.x / tileSize;
-            double py = meters.y / tileSize;
-
-            int tileX = (int)(Math.Ceiling(px) - 1);
-            int tileY = (int)(Math.Ceiling(py) - 1);
+            int tileX = (int)(meters.x / tileSize);
+            int tileY = (int)(meters.y / tileSize);
 
             return new TileAddress(tileX, tileY, zoom);
         }

--- a/Assets/Mapzen/TileAddress.cs
+++ b/Assets/Mapzen/TileAddress.cs
@@ -14,16 +14,15 @@ namespace Mapzen
 
         public static TileAddress FromLngLat(LngLat lngLat, int zoom)
         {
-            double tileResolution = Geo.EarthCircumferenceMeters / Geo.TilePixelSize;
-            double tileSize = tileResolution / (1 << zoom);
+            double tileSize = Geo.EarthCircumferenceMeters / (1 << zoom);
 
             MercatorMeters meters = Geo.Project(lngLat);
 
             double px = meters.x / tileSize;
             double py = meters.y / tileSize;
 
-            int tileX = (int)(Math.Ceiling(px / Geo.TilePixelSize) - 1);
-            int tileY = (int)(Math.Ceiling(py / Geo.TilePixelSize) - 1);
+            int tileX = (int)(Math.Ceiling(px) - 1);
+            int tileY = (int)(Math.Ceiling(py) - 1);
 
             return new TileAddress(tileX, tileY, zoom);
         }

--- a/Assets/Mapzen/TileBounds.cs
+++ b/Assets/Mapzen/TileBounds.cs
@@ -33,19 +33,22 @@ namespace Mapzen
             max = TileAddress.FromLngLat(area.max, area.zoom);
         }
 
-        public IEnumerable<TileAddress> TileAddressRange()
+        public IEnumerable<TileAddress> TileAddressRange
         {
-            int startX = min.x;
-            int startY = max.y;
-
-            int rangeX = Math.Abs(max.x - min.x);
-            int rangeY = Math.Abs(max.y - min.y);
-
-            for (int x = 0; x <= rangeX; ++x)
+            get
             {
-                for (int y = 0; y <= rangeY; ++y)
+                int startX = min.x;
+                int startY = max.y;
+
+                int rangeX = Math.Abs(max.x - min.x);
+                int rangeY = Math.Abs(max.y - min.y);
+
+                for (int x = 0; x <= rangeX; ++x)
                 {
-                    yield return new TileAddress(startX + x, startY + y, area.zoom);
+                    for (int y = 0; y <= rangeY; ++y)
+                    {
+                        yield return new TileAddress(startX + x, startY + y, area.zoom);
+                    }
                 }
             }
         }

--- a/Assets/Mapzen/TileBounds.cs
+++ b/Assets/Mapzen/TileBounds.cs
@@ -29,8 +29,20 @@ namespace Mapzen
         {
             this.area = area;
 
-            min = TileAddress.FromLngLat(area.min, area.zoom);
-            max = TileAddress.FromLngLat(area.max, area.zoom);
+            LngLat minLngLat = area.min;
+            LngLat maxLngLat = area.max;
+
+            if (minLngLat.latitude > maxLngLat.latitude)
+            {
+                Util.Swap(ref minLngLat.latitude, ref maxLngLat.latitude);
+            }
+            if (minLngLat.longitude > maxLngLat.longitude)
+            {
+                Util.Swap(ref minLngLat.longitude, ref maxLngLat.longitude);
+            }
+
+            min = TileAddress.FromLngLat(minLngLat, area.zoom);
+            max = TileAddress.FromLngLat(maxLngLat, area.zoom);
         }
 
         public IEnumerable<TileAddress> TileAddressRange

--- a/Assets/Mapzen/TileBounds.cs
+++ b/Assets/Mapzen/TileBounds.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+namespace Mapzen
+{
+    [System.Serializable]
+    public struct TileArea
+    {
+        public LngLat min;
+        public LngLat max;
+        public int zoom;
+
+        public TileArea(LngLat min, LngLat max, int zoom)
+        {
+            this.min = min;
+            this.max = max;
+            this.zoom = zoom;
+        }
+    }
+
+    public class TileBounds
+    {
+        public readonly TileAddress min;
+        public readonly TileAddress max;
+
+        private TileArea area;
+
+        public TileBounds(TileArea area)
+        {
+            this.area = area;
+
+            min = TileAddress.FromLngLat(area.min, area.zoom);
+            max = TileAddress.FromLngLat(area.max, area.zoom);
+        }
+
+        public IEnumerable<TileAddress> TileAddressRange()
+        {
+            int startX = min.x;
+            int startY = max.y;
+
+            int rangeX = Math.Abs(max.x - min.x);
+            int rangeY = Math.Abs(max.y - min.y);
+
+            for (int x = 0; x <= rangeX; ++x)
+            {
+                for (int y = 0; y <= rangeY; ++y)
+                {
+                    yield return new TileAddress(startX + x, startY + y, area.zoom);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Mapzen/TileBounds.cs.meta
+++ b/Assets/Mapzen/TileBounds.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 09e0371421afc429db4439b5e186c79a
+timeCreated: 1498683135
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mapzen/Util.cs
+++ b/Assets/Mapzen/Util.cs
@@ -1,0 +1,14 @@
+
+namespace Mapzen
+{
+    class Util
+    {
+        public static void Swap<T>(ref T lhs, ref T rhs)
+        {
+            T temp;
+            temp = lhs;
+            lhs = rhs;
+            rhs = temp;
+        }
+    }
+}

--- a/Assets/Mapzen/Util.cs.meta
+++ b/Assets/Mapzen/Util.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a3fae40e25035474986b4cdb0eb31ef8
+timeCreated: 1499447211
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mapzen/VectorData/GeoJSON.cs
+++ b/Assets/Mapzen/VectorData/GeoJSON.cs
@@ -14,7 +14,7 @@ namespace Mapzen
             return delegate(LngLat lngLat)
             {
                 var meters = lngLat.ToMercatorMeters();
-                var origin = address.GetOriginMercatorMeters();
+                var origin = address.Wrapped().GetOriginMercatorMeters();
                 var scale = address.GetSizeMercatorMeters();
                 var x = (meters.x - origin.x) / scale;
                 var y = (origin.y - meters.y) / scale;

--- a/Assets/Mapzen/VectorData/GeoJSON.cs
+++ b/Assets/Mapzen/VectorData/GeoJSON.cs
@@ -17,7 +17,7 @@ namespace Mapzen
                 var origin = address.GetOriginMercatorMeters();
                 var scale = address.GetSizeMercatorMeters();
                 var x = (meters.x - origin.x) / scale;
-                var y = (meters.y - origin.y) / scale;
+                var y = (origin.y - meters.y) / scale;
                 return new Point((float)x, (float)y);
             };
         }

--- a/Assets/MapzenMap.cs
+++ b/Assets/MapzenMap.cs
@@ -77,7 +77,7 @@ public class MapzenMap : MonoBehaviour
                     TileTask task = new TileTask(address, layers, response, tile);
 
                     task.offsetX = (address.x - TileX);
-                    task.offsetY = (address.y - TileY);
+                    task.offsetY = TileRangeY - (address.y - TileY);
 
                     pendingTasks.Add(task);
 

--- a/Assets/MapzenMap.cs
+++ b/Assets/MapzenMap.cs
@@ -9,14 +9,9 @@ public class MapzenMap : MonoBehaviour
 {
     delegate void HTTPRequestCallback(string error,string response,TileAddress address);
 
-    public int TileX = 19290;
-    public int TileY = 24632;
-    public int TileZ = 16;
-
-    public int TileRangeX = 5;
-    public int TileRangeY = 5;
-
     public string ApiKey = "vector-tiles-tyHL4AY";
+
+    public TileArea Area = new TileArea(new LngLat(-74.014892578125, 40.70562793820589), new LngLat(-74.00390625, 40.713955826286046), 16);
 
     #if UNITY_WEBGL
     private const int nWorkers = 0;
@@ -29,70 +24,61 @@ public class MapzenMap : MonoBehaviour
 
     void Start()
     {
-        TileAddress addr = TileAddress.FromLngLat(new LngLat(-73.935242, 40.730610), 16, 256);
+        TileBounds bounds = new TileBounds(Area);
 
-        // Construct the HTTP request
-        for (int x = 0; x < TileRangeX; ++x)
+        foreach (var tileAddress in bounds.TileAddressRange())
         {
-            for (int y = 0; y < TileRangeY; ++y)
+            var url = string.Format("https://tile.mapzen.com/mapzen/vector/v1/all/{0}/{1}/{2}.json?api_key={3}",
+                          tileAddress.z, tileAddress.x, tileAddress.y, ApiKey);
+
+            HTTPRequestCallback callback = (string error, string response, TileAddress address) =>
             {
-                int tileX = TileX + x;
-                int tileY = TileY + y;
-
-                var url = string.Format("https://tile.mapzen.com/mapzen/vector/v1/all/{0}/{1}/{2}.json?api_key={3}",
-                              TileZ, tileX, tileY, ApiKey);
-
-                Debug.Log("URL request " + url);
-
-                HTTPRequestCallback callback = (string error, string response, TileAddress address) =>
+                if (error != null)
                 {
-                    if (error != null)
-                    {
-                        Debug.Log("Error: " + error);
-                        return;
-                    }
+                    Debug.Log("Error: " + error);
+                    return;
+                }
 
-                    if (response.Length == 0)
-                    {
-                        Debug.Log("Empty response");
-                        return;
-                    }
+                if (response.Length == 0)
+                {
+                    Debug.Log("Empty response");
+                    return;
+                }
 
-                    // Debug.Log("Response: " + response);
+                // Debug.Log("Response: " + response);
 
-                    // Adding a tile object to the scene
-                    GameObject tilePrefab = Resources.Load("Tile") as GameObject;
+                // Adding a tile object to the scene
+                GameObject tilePrefab = Resources.Load("Tile") as GameObject;
 
-                    // Instantiate a prefab running the script TileData.Start()
-                    var go = Instantiate(tilePrefab);
+                // Instantiate a prefab running the script TileData.Start()
+                var go = Instantiate(tilePrefab);
 
-                    MapTile tile = go.GetComponent<MapTile>();
+                MapTile tile = go.GetComponent<MapTile>();
 
-                    var layers = new List<string>
-                    {
-                        "water",
-                        "roads",
-                        "earth",
-                        "buildings"
-                    };
-
-                    TileTask task = new TileTask(address, layers, response, tile);
-
-                    task.offsetX = (address.x - TileX);
-                    task.offsetY = TileRangeY - (address.y - TileY);
-
-                    pendingTasks.Add(task);
-
-                    worker.RunAsync(() =>
-                        {
-                            task.Start();
-                        });
+                var layers = new List<string>
+                {
+                    "water",
+                    "roads",
+                    "earth",
+                    "buildings"
                 };
-                UnityWebRequest request = UnityWebRequest.Get(url);
 
-                // Starts the HTTP request
-                StartCoroutine(DoHTTPRequest(request, callback, new TileAddress(tileX, tileY, TileZ)));
-            }
+                TileTask task = new TileTask(address, layers, response, tile);
+
+                task.offsetX = (address.x - bounds.min.x);
+                task.offsetY = (-address.y + bounds.min.y);
+
+                pendingTasks.Add(task);
+
+                worker.RunAsync(() =>
+                    {
+                        task.Start();
+                    });
+            };
+            UnityWebRequest request = UnityWebRequest.Get(url);
+
+            // Starts the HTTP request
+            StartCoroutine(DoHTTPRequest(request, callback, tileAddress));
         }
     }
 

--- a/Assets/MapzenMap.cs
+++ b/Assets/MapzenMap.cs
@@ -26,7 +26,7 @@ public class MapzenMap : MonoBehaviour
     {
         TileBounds bounds = new TileBounds(Area);
 
-        foreach (var tileAddress in bounds.TileAddressRange())
+        foreach (var tileAddress in bounds.TileAddressRange)
         {
             var url = string.Format("https://tile.mapzen.com/mapzen/vector/v1/all/{0}/{1}/{2}.json?api_key={3}",
                           tileAddress.z, tileAddress.x, tileAddress.y, ApiKey);

--- a/Assets/MapzenMap.cs
+++ b/Assets/MapzenMap.cs
@@ -29,6 +29,8 @@ public class MapzenMap : MonoBehaviour
 
     void Start()
     {
+        TileAddress addr = TileAddress.FromLngLat(new LngLat(-73.935242, 40.730610), 16, 256);
+
         // Construct the HTTP request
         for (int x = 0; x < TileRangeX; ++x)
         {

--- a/Assets/MapzenMap.cs
+++ b/Assets/MapzenMap.cs
@@ -28,8 +28,9 @@ public class MapzenMap : MonoBehaviour
 
         foreach (var tileAddress in bounds.TileAddressRange)
         {
+            var wrappedTileAddress = tileAddress.Wrapped();
             var url = string.Format("https://tile.mapzen.com/mapzen/vector/v1/all/{0}/{1}/{2}.json?api_key={3}",
-                          tileAddress.z, tileAddress.x, tileAddress.y, ApiKey);
+                          wrappedTileAddress.z, wrappedTileAddress.x, wrappedTileAddress.y, ApiKey);
 
             HTTPRequestCallback callback = (string error, string response, TileAddress address) =>
             {


### PR DESCRIPTION
Scan tile ranges for two given lat/lon and expose it in the Unity interface.

![screen shot 2017-06-29 at 12 01 05](https://user-images.githubusercontent.com/7061573/27697599-c11875c6-5cc2-11e7-8a34-627fa03f3e7a.png)


