### PR TITLE
Tile generation and export workflow in Editor mode

### DIFF
--- a/Assets/Earcut.cs
+++ b/Assets/Earcut.cs
@@ -5,11 +5,11 @@ using System.Diagnostics;
 public class Earcut
 {
     private const string LibraryName =
-#if (UNITY_IOS || UNITY_WEBGL)
+    #if (UNITY_IOS || UNITY_WEBGL)
         "__Internal";
-#else
+    #else
         "Earcut";
-#endif
+    #endif
 
     [DllImport(LibraryName, EntryPoint = "CreateTesselationContext")]
     private static extern uint CreateTesselationContext();
@@ -28,9 +28,9 @@ public class Earcut
 
     private uint contextId;
 
-    public int[] indices { get; internal set; }
+    public int[] Indices { get; internal set; }
 
-    public float[] vertices { get; internal set; }
+    public float[] Vertices { get; internal set; }
 
     public Earcut()
     {
@@ -51,11 +51,11 @@ public class Earcut
         pointsBufferHandle.Free();
         ringsBufferHandle.Free();
 
-        indices = new int[nIndices];
-        vertices = new float[nVertices * 2];
+        Indices = new int[nIndices];
+        Vertices = new float[nVertices * 2];
 
-        GCHandle indicesBufferHandle = GCHandle.Alloc(indices, GCHandleType.Pinned);
-        GCHandle verticesBufferHandle = GCHandle.Alloc(vertices, GCHandleType.Pinned);
+        GCHandle indicesBufferHandle = GCHandle.Alloc(Indices, GCHandleType.Pinned);
+        GCHandle verticesBufferHandle = GCHandle.Alloc(Vertices, GCHandleType.Pinned);
 
         GetIndices(contextId, indicesBufferHandle.AddrOfPinnedObject());
         GetVertices(contextId, verticesBufferHandle.AddrOfPinnedObject());

--- a/Assets/Editor.meta
+++ b/Assets/Editor.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: f41e6076f043149d091a13c6cd03e61c
+folderAsset: yes
+timeCreated: 1499454478
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/EditorUtil.cs
+++ b/Assets/Editor/EditorUtil.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using UnityEditor;
+using UnityEngine;
+
+public class EditorUtil
+{
+    public static void FloatField(ref string view, ref float value, GUILayoutOption options)
+    {
+        var str = GUILayout.TextField(view, options);
+
+        float floatField = 0.0f;
+
+        if (str.Length == 0)
+        {
+            value = 0.0f;
+            view = "";
+        }
+        else if (float.TryParse(str, out floatField))
+        {
+            value = floatField;
+            view = str;
+        }
+    }
+}
+

--- a/Assets/Editor/EditorUtil.cs.meta
+++ b/Assets/Editor/EditorUtil.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5b676cf2cc47e41819bb1ce4fd05294a
+timeCreated: 1501107316
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/FeatureFilterEditor.cs
+++ b/Assets/Editor/FeatureFilterEditor.cs
@@ -1,0 +1,91 @@
+using UnityEngine;
+using UnityEditor;
+using Mapzen;
+using Mapzen.VectorData.Filters;
+using System.Collections.Generic;
+using System;
+
+public class FeatureFilterEditor
+{
+    private bool show = false;
+    private IFeatureFilter filter;
+
+    private static GUILayoutOption buttonWidth = GUILayout.Width(50.0f);
+    private static GUIContent addLayerButtonContent =
+        new GUIContent("+", "Add layer collection");
+    private static GUIContent removeLayerButtonContent =
+        new GUIContent("-", "Remove layer collection");
+
+    private string customFeatureCollection = "";
+    private int selectedLayer;
+    private List<string> layers = new List<string>();
+    private List<string> defaultLayers = new List<string>(new string[]
+        {
+            "boundaries",
+            "buildings",
+            "earth",
+            "landuse",
+            "places",
+            "pois",
+            "roads",
+            "transit",
+            "water"
+        });
+
+
+    public FeatureFilterEditor()
+    {
+    }
+
+    public IFeatureFilter OnInspectorGUI()
+    {
+        // Default layers
+        EditorGUILayout.BeginHorizontal();
+        {
+            selectedLayer = EditorGUILayout.Popup("Default layer:",
+                    selectedLayer, defaultLayers.ToArray());
+
+            if (GUILayout.Button(addLayerButtonContent, buttonWidth))
+            {
+                layers.Add(defaultLayers[selectedLayer]);
+            }
+        }
+        EditorGUILayout.EndHorizontal();
+
+        // Custom layer entry
+        EditorGUILayout.BeginHorizontal();
+        {
+            GUILayout.Label("Custom layer:");
+            customFeatureCollection = GUILayout.TextField(customFeatureCollection);
+
+            if (GUILayout.Button(addLayerButtonContent, buttonWidth)
+                && customFeatureCollection.Length > 0)
+            {
+                layers.Add(customFeatureCollection);
+            }
+        }
+        EditorGUILayout.EndHorizontal();
+
+        GUILayout.Space(10);
+
+        // Show currently create filters
+        if (layers.Count > 0)
+        {
+            GUILayout.Label("Filter layers:");
+
+            for (int i = layers.Count - 1; i >= 0; i--)
+            {
+                EditorGUILayout.BeginHorizontal();
+                string layer = layers[i];
+                GUILayout.TextField(layer);
+                if (GUILayout.Button(removeLayerButtonContent, buttonWidth))
+                {
+                    layers.RemoveAt(i);
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+        }
+
+        return new FeatureFilter().TakeAllFromCollections(layers.ToArray());
+    }
+}

--- a/Assets/Editor/FeatureFilterEditor.cs
+++ b/Assets/Editor/FeatureFilterEditor.cs
@@ -33,10 +33,6 @@ public class FeatureFilterEditor
         });
 
 
-    public FeatureFilterEditor()
-    {
-    }
-
     public IFeatureFilter OnInspectorGUI()
     {
         // Default layers

--- a/Assets/Editor/FeatureFilterEditor.cs.meta
+++ b/Assets/Editor/FeatureFilterEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a129fdd0efa0241d1aff56f35f7da658
+timeCreated: 1500932283
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/FeatureStyleEditor.cs
+++ b/Assets/Editor/FeatureStyleEditor.cs
@@ -1,0 +1,83 @@
+using UnityEngine;
+using UnityEditor;
+using Mapzen;
+using Mapzen.VectorData.Filters;
+using System.Collections.Generic;
+using System;
+
+public class FeatureStyleEditor
+{
+    private PolylineBuilderEditor polylineBuilderEditor;
+    private PolygonBuilderEditor polygonBuilderEditor;
+    private FeatureFilterEditor featureFilterEditor;
+    private Material featureMaterial;
+
+    private bool show = true;
+
+    public FeatureStyleEditor()
+    {
+        polygonBuilderEditor = new PolygonBuilderEditor();
+        polylineBuilderEditor = new PolylineBuilderEditor();
+        featureFilterEditor = new FeatureFilterEditor();
+    }
+
+    public FeatureStyle OnInspectorGUI(MapzenMap mapzenMap)
+    {
+        FeatureStyle featureStyle = null;
+
+        show = EditorGUILayout.Foldout(show, "Feature collection filtering");
+        if (!show)
+        {
+            return featureStyle;
+        }
+
+        // Material associated with the filter
+        EditorGUILayout.BeginHorizontal();
+        {
+            GUILayout.Label("Filter material:");
+            featureMaterial = EditorGUILayout.ObjectField(featureMaterial, typeof(Material)) as Material;
+        }
+        EditorGUILayout.EndHorizontal();
+
+        var featureFilter = featureFilterEditor.OnInspectorGUI();
+        var polygonOptions = polygonBuilderEditor.OnInspectorGUI();
+        var polylineOptions = polylineBuilderEditor.OnInspectorGUI();
+
+        if (GUILayout.Button("Create Filter")
+            && featureMaterial != null
+            && featureFilter != null)
+        {
+            featureStyle = new FeatureStyle(featureFilter, featureMaterial,
+                polygonOptions, polylineOptions);
+
+            mapzenMap.FeatureStyling.Add(featureStyle);
+        }
+
+        GUILayout.Space(10);
+
+        // Show available filters
+        if (mapzenMap.FeatureStyling.Count > 0)
+        {
+            GUILayout.Label("Filters:");
+
+            foreach (var featureStyling in mapzenMap.FeatureStyling)
+            {
+                FeatureFilter filter = featureStyling.Filter as FeatureFilter;
+                EditorGUILayout.BeginHorizontal();
+                foreach (var layer in filter.CollectionNameSet)
+                {
+                    GUILayout.TextField(layer);
+                }
+                GUILayout.TextField(featureStyling.Material.name);
+                EditorGUILayout.EndHorizontal();
+            }
+
+            if (GUILayout.Button("Remove filters"))
+            {
+                mapzenMap.FeatureStyling.Clear();
+            }
+        }
+
+        return featureStyle;
+    }
+}

--- a/Assets/Editor/FeatureStyleEditor.cs.meta
+++ b/Assets/Editor/FeatureStyleEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: bb38e7221e60446079677b10d7b06d3e
+timeCreated: 1500994957
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/MapzenMapEditor.cs
+++ b/Assets/Editor/MapzenMapEditor.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+using UnityEditor;
+using Mapzen;
+
+[CustomEditor(typeof(MapzenMap))]
+public class MapzenMapEditor : Editor, MapzenMap.IMapzenMapListener
+{
+    private MapzenMap mapzenMap;
+
+    void OnEnable()
+    {
+        mapzenMap = (MapzenMap)target;
+
+        // Register as listener on download completion
+        mapzenMap.Listener = this;
+    }
+
+    public override void OnInspectorGUI()
+    {
+        GUILayout.Label("Mapzen map Editor configuration");
+
+        GUILayout.Space(10);
+
+        base.OnInspectorGUI();
+    }
+
+    public void OnGameObjectReady(GameObject go)
+    {
+        var prefab = PrefabUtility.CreateEmptyPrefab("Assets/" + go.name + ".prefab");
+        var serializedPrefab = PrefabUtility.ReplacePrefab(go, prefab, ReplacePrefabOptions.ConnectToPrefab);
+
+        var meshFilter = go.GetComponent<MeshFilter>().mesh;
+        var materials = go.GetComponent<MeshRenderer>().materials;
+
+        serializedPrefab.GetComponent<MeshFilter>().mesh = meshFilter;
+        serializedPrefab.GetComponent<MeshRenderer>().materials = materials;
+
+        AssetDatabase.CreateAsset(meshFilter, "Assets/" + go.name + "-mesh.asset");
+    }
+}

--- a/Assets/Editor/MapzenMapEditor.cs
+++ b/Assets/Editor/MapzenMapEditor.cs
@@ -142,7 +142,7 @@ public class MapzenMapEditor : Editor
             var featureFilter = new FeatureFilter()
                 .TakeAllFromCollections(layers.ToArray());
 
-            mapzenMap.FeatureStyling.Add(featureFilter, featureMaterial);
+            mapzenMap.FeatureStyling.Add(new FeatureStyle(featureFilter, featureMaterial));
         }
 
         GUILayout.Space(10);
@@ -154,13 +154,13 @@ public class MapzenMapEditor : Editor
 
             foreach (var featureStyling in mapzenMap.FeatureStyling)
             {
-                FeatureFilter filter = featureStyling.Key as FeatureFilter;
+                FeatureFilter filter = featureStyling.Filter as FeatureFilter;
                 EditorGUILayout.BeginHorizontal();
                 foreach (var layer in filter.CollectionNameSet)
                 {
                     GUILayout.TextField(layer);
                 }
-                GUILayout.TextField(featureStyling.Value.name);
+                GUILayout.TextField(featureStyling.Material.name);
                 EditorGUILayout.EndHorizontal();
             }
 

--- a/Assets/Editor/MapzenMapEditor.cs
+++ b/Assets/Editor/MapzenMapEditor.cs
@@ -28,6 +28,10 @@ public class MapzenMapEditor : Editor
         {
             ExportGameObjects();
         }
+        if (GUILayout.Button("Download"))
+        {
+            mapzenMap.DownloadTiles();
+        }
 
         EditorUtility.ClearProgressBar();
 

--- a/Assets/Editor/MapzenMapEditor.cs
+++ b/Assets/Editor/MapzenMapEditor.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using UnityEditor;
 using Mapzen;
+using Mapzen.VectorData.Filters;
 using System;
 using System.IO;
 
@@ -8,6 +9,8 @@ using System.IO;
 public class MapzenMapEditor : Editor
 {
     private MapzenMap mapzenMap;
+    private string featureCollection = "";
+    private Material featureMaterial;
 
     void OnEnable()
     {
@@ -30,7 +33,27 @@ public class MapzenMapEditor : Editor
         }
         if (GUILayout.Button("Download"))
         {
+            ClearTiles();
             mapzenMap.DownloadTiles();
+        }
+        if (GUILayout.Button("Clear"))
+        {
+            ClearTiles();
+        }
+
+        featureCollection = GUILayout.TextField(featureCollection);
+        EditorGUILayout.BeginHorizontal();
+        featureMaterial = EditorGUILayout.ObjectField(featureMaterial, typeof(Material)) as Material;
+        EditorGUILayout.EndHorizontal();
+
+        if (GUILayout.Button("AddFilter")
+            && featureMaterial != null
+            && featureCollection.Length > 0)
+        {
+            var featureFilter = new FeatureFilter()
+                .TakeAllFromCollections(featureCollection);
+
+            mapzenMap.FeatureStyling.Add(featureFilter, featureMaterial);
         }
 
         EditorUtility.ClearProgressBar();
@@ -38,6 +61,15 @@ public class MapzenMapEditor : Editor
         GUILayout.Space(10);
 
         base.OnInspectorGUI();
+    }
+
+    public void ClearTiles()
+    {
+        for (int i = 0; i < mapzenMap.Tiles.Count; ++i)
+        {
+            DestroyImmediate(mapzenMap.Tiles[i]);
+        }
+        mapzenMap.Tiles.Clear();
     }
 
     private static bool CreateDirectoryAtPath(string path)

--- a/Assets/Editor/MapzenMapEditor.cs
+++ b/Assets/Editor/MapzenMapEditor.cs
@@ -6,20 +6,20 @@ public class MapzenMapEditor : Editor
 {
     private MapzenMap mapzenMap;
 
-    private FeatureStyleEditor featureStyleEditor;
-    private TileDataEditor tileDataEditor;
+    private FeatureStyleEditor featureStyleEditor = new FeatureStyleEditor();
+    private TileDataEditor tileDataEditor = new TileDataEditor();
 
     void OnEnable()
     {
         mapzenMap = (MapzenMap)target;
-        featureStyleEditor = new FeatureStyleEditor();
-        tileDataEditor = new TileDataEditor();
     }
 
     public override void OnInspectorGUI()
     {
         featureStyleEditor.OnInspectorGUI(mapzenMap);
+
         tileDataEditor.OnInspectorGUI(mapzenMap);
+
         base.OnInspectorGUI();
     }
 }

--- a/Assets/Editor/MapzenMapEditor.cs
+++ b/Assets/Editor/MapzenMapEditor.cs
@@ -18,6 +18,7 @@ public class MapzenMapEditor : Editor
     private static GUIContent addLayerButtonContent = new GUIContent("+", "Add layer collection");
     private static GUIContent removeLayerButtonContent = new GUIContent("-", "Remove layer collection");
     private List<string> layers = new List<string>();
+    private int selectedLayer;
     private List<string> defaultLayers = new List<string>(new string[]
         {
             "boundaries",
@@ -82,22 +83,19 @@ public class MapzenMapEditor : Editor
 
         // Default layers
         {
-            foreach (var defaultLayer in defaultLayers)
+            EditorGUILayout.BeginHorizontal();
+            selectedLayer = EditorGUILayout.Popup("Default layer:", selectedLayer, defaultLayers.ToArray());
+            if (GUILayout.Button(addLayerButtonContent, buttonWidth))
             {
-                EditorGUILayout.BeginHorizontal();
-                GUILayout.Label(defaultLayer);
-                if (GUILayout.Button(addLayerButtonContent, buttonWidth))
-                {
-                    layers.Add(defaultLayer);
-                }
-                EditorGUILayout.EndHorizontal();
+                layers.Add(defaultLayers[selectedLayer]);
             }
+            EditorGUILayout.EndHorizontal();
         }
 
         // Custom layer entry
         {
             EditorGUILayout.BeginHorizontal();
-            GUILayout.Label("Custom:");
+            GUILayout.Label("Custom layer:");
             customFeatureCollection = GUILayout.TextField(customFeatureCollection);
             if (GUILayout.Button(addLayerButtonContent, buttonWidth)
                 && customFeatureCollection.Length > 0)

--- a/Assets/Editor/MapzenMapEditor.cs
+++ b/Assets/Editor/MapzenMapEditor.cs
@@ -1,211 +1,25 @@
 using UnityEngine;
 using UnityEditor;
-using Mapzen;
-using Mapzen.VectorData.Filters;
-using System;
-using System.Collections.Generic;
-using System.IO;
 
 [CustomEditor(typeof(MapzenMap))]
 public class MapzenMapEditor : Editor
 {
     private MapzenMap mapzenMap;
-    private Material featureMaterial;
 
-    private PolylineBuilderEditor polylineBuilderEditor;
-    private PolygonBuilderEditor polygonBuilderEditor;
-    private FeatureFilterEditor featureFilterEditor;
-
-    private bool showFeatureStyleGUI = true;
-    private bool showExportGUI = true;
+    private FeatureStyleEditor featureStyleEditor;
+    private TileDataEditor tileDataEditor;
 
     void OnEnable()
     {
         mapzenMap = (MapzenMap)target;
-
-        polygonBuilderEditor = new PolygonBuilderEditor();
-        polylineBuilderEditor = new PolylineBuilderEditor();
-        featureFilterEditor = new FeatureFilterEditor();
+        featureStyleEditor = new FeatureStyleEditor();
+        tileDataEditor = new TileDataEditor();
     }
 
     public override void OnInspectorGUI()
     {
-        FeatureStyleGUI();
-
-        ExportGUI();
-
+        featureStyleEditor.OnInspectorGUI(mapzenMap);
+        tileDataEditor.OnInspectorGUI(mapzenMap);
         base.OnInspectorGUI();
-    }
-
-    private void ExportGUI()
-    {
-        showExportGUI = EditorGUILayout.Foldout(showExportGUI, "Data");
-        if (!showExportGUI)
-        {
-            return;
-        }
-
-        if (GUILayout.Button("Download"))
-        {
-            ClearTiles();
-            mapzenMap.DownloadTiles();
-        }
-
-        GUILayout.Label("Export path:");
-        mapzenMap.ExportPath = GUILayout.TextField(mapzenMap.ExportPath);
-        if (GUILayout.Button("Export"))
-        {
-            ExportGameObjects();
-        }
-
-        if (GUILayout.Button("Clear"))
-        {
-            ClearTiles();
-        }
-    }
-
-    private void FeatureStyleGUI()
-    {
-        showFeatureStyleGUI = EditorGUILayout.Foldout(showFeatureStyleGUI, "Feature collection filtering");
-        if (!showFeatureStyleGUI)
-        {
-            return;
-        }
-
-        // Material associated with the filter
-        EditorGUILayout.BeginHorizontal();
-        {
-            GUILayout.Label("Filter material:");
-            featureMaterial = EditorGUILayout.ObjectField(featureMaterial, typeof(Material)) as Material;
-        }
-        EditorGUILayout.EndHorizontal();
-
-        var featureFilter = featureFilterEditor.OnInspectorGUI();
-        var polygonOptions = polygonBuilderEditor.OnInspectorGUI();
-        var polylineOptions = polylineBuilderEditor.OnInspectorGUI();
-
-        if (GUILayout.Button("Create Filter")
-            && featureMaterial != null
-            && featureFilter != null)
-        {
-            var featureStyle = new FeatureStyle(featureFilter, featureMaterial,
-                    polygonOptions, polylineOptions);
-            mapzenMap.FeatureStyling.Add(featureStyle);
-        }
-
-        GUILayout.Space(10);
-
-        // Show available filters
-        if (mapzenMap.FeatureStyling.Count > 0)
-        {
-            GUILayout.Label("Filters:");
-
-            foreach (var featureStyling in mapzenMap.FeatureStyling)
-            {
-                FeatureFilter filter = featureStyling.Filter as FeatureFilter;
-                EditorGUILayout.BeginHorizontal();
-                foreach (var layer in filter.CollectionNameSet)
-                {
-                    GUILayout.TextField(layer);
-                }
-                GUILayout.TextField(featureStyling.Material.name);
-                EditorGUILayout.EndHorizontal();
-            }
-
-            if (GUILayout.Button("Remove filters"))
-            {
-                mapzenMap.FeatureStyling.Clear();
-            }
-        }
-    }
-
-    public void ClearTiles()
-    {
-        for (int i = 0; i < mapzenMap.Tiles.Count; ++i)
-        {
-            DestroyImmediate(mapzenMap.Tiles[i]);
-        }
-        mapzenMap.Tiles.Clear();
-    }
-
-    private void ExportGameObjects()
-    {
-        if (!CreateDirectoryAtPath(mapzenMap.ExportPath))
-        {
-            EditorUtility.DisplayDialog("Please provide a valid export path",
-                "Unable to create or locate directory at path" + mapzenMap.ExportPath,
-                "Ok");
-
-            return;
-        }
-
-        for (int i = 0; i < mapzenMap.Tiles.Count; ++i)
-        {
-            var tile = mapzenMap.Tiles[i];
-
-            float progress = (float)(i + 1) / mapzenMap.Tiles.Count;
-            EditorUtility.DisplayProgressBar("Exporting tile assets",
-                "Exporting tile asset " + tile.name,
-                progress);
-
-            string tileAssetPath = mapzenMap.ExportPath + "/" + tile.name;
-
-            if (CreateDirectoryAtPath(tileAssetPath))
-            {
-                SaveGameObjectToDisk(tile, tileAssetPath);
-            }
-            else
-            {
-                Debug.LogError("Unable to save tile at path " + tileAssetPath);
-            }
-        }
-
-        EditorUtility.ClearProgressBar();
-    }
-
-    private void SaveGameObjectToDisk(GameObject go, string rootPath)
-    {
-        var prefab = PrefabUtility.CreateEmptyPrefab(rootPath + "/" + go.name + ".prefab");
-        var serializedPrefab = PrefabUtility.ReplacePrefab(go, prefab, ReplacePrefabOptions.ConnectToPrefab);
-
-        var meshFilter = go.GetComponent<MeshFilter>().sharedMesh;
-        var materials = go.GetComponent<MeshRenderer>().materials;
-
-        serializedPrefab.GetComponent<MeshFilter>().mesh = meshFilter;
-        serializedPrefab.GetComponent<MeshRenderer>().materials = materials;
-
-        for (int i = 0; i < materials.Length; ++i)
-        {
-            // TODO: give better name to materials
-            AssetDatabase.CreateAsset(materials[i], rootPath + "/" + materials[i].name + i + ".mat");
-        }
-
-        AssetDatabase.CreateAsset(meshFilter, rootPath + "/" + go.name + ".asset");
-        AssetDatabase.SaveAssets();
-    }
-
-    private static bool CreateDirectoryAtPath(string path)
-    {
-        if (path == "")
-        {
-            return false;
-        }
-
-        if (Directory.Exists(path))
-        {
-            return true;
-        }
-
-        try
-        {
-            Directory.CreateDirectory(path);
-            return true;
-        }
-        catch (Exception e)
-        {
-            Debug.Log(e);
-        }
-
-        return false;
     }
 }

--- a/Assets/Editor/MapzenMapEditor.cs
+++ b/Assets/Editor/MapzenMapEditor.cs
@@ -39,6 +39,7 @@ public class MapzenMapEditor : Editor
         if (GUILayout.Button("Clear"))
         {
             ClearTiles();
+            mapzenMap.FeatureStyling.Clear();
         }
 
         featureCollection = GUILayout.TextField(featureCollection);

--- a/Assets/Editor/MapzenMapEditor.cs.meta
+++ b/Assets/Editor/MapzenMapEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 468cdd21d7ed14f9e8004236a738b258
+timeCreated: 1499454741
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/MapzenMapEditor.prefab
+++ b/Assets/Editor/MapzenMapEditor.prefab
@@ -1,0 +1,59 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1795746876304430}
+  m_IsPrefabParent: 1
+--- !u!1 &1795746876304430
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 4687856860202350}
+  - component: {fileID: 114127161518583280}
+  m_Layer: 0
+  m_Name: Mapzen
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4687856860202350
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1795746876304430}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &114127161518583280
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1795746876304430}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f99f332e167bc4c5cb799d5f5171e0b0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  TileX: 19293
+  TileY: 24640
+  TileZ: 16
+  TileRangeX: 4
+  TileRangeY: 4
+  ApiKey: vector-tiles-tyHL4AY

--- a/Assets/Editor/MapzenMapEditor.prefab
+++ b/Assets/Editor/MapzenMapEditor.prefab
@@ -21,7 +21,7 @@ GameObject:
   - component: {fileID: 4687856860202350}
   - component: {fileID: 114127161518583280}
   m_Layer: 0
-  m_Name: Mapzen
+  m_Name: MapzenMapEditor
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0

--- a/Assets/Editor/MapzenMapEditor.prefab.meta
+++ b/Assets/Editor/MapzenMapEditor.prefab.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 30957f35561a24466950c2ffdaa6b469
+timeCreated: 1499454759
+licenseType: Free
+NativeFormatImporter:
+  mainObjectFileID: 100100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/PolygonBuilderEditor.cs
+++ b/Assets/Editor/PolygonBuilderEditor.cs
@@ -32,12 +32,7 @@ public class PolygonBuilderEditor
         GUILayout.BeginHorizontal();
         {
             GUILayout.Label("Max Height: ");
-            maxHeight = GUILayout.TextField(maxHeight, layoutWidth);
-            try {
-                options.MaxHeight = float.Parse(maxHeight);
-            } catch (FormatException) {
-                Debug.Log("Invalid number given for PolygonBuilder.MaxHeight");
-            }
+            EditorUtil.FloatField(ref maxHeight, ref options.MaxHeight, layoutWidth);
         }
         GUILayout.EndHorizontal();
 

--- a/Assets/Editor/PolygonBuilderEditor.cs
+++ b/Assets/Editor/PolygonBuilderEditor.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using UnityEditor;
+using Mapzen;
+
+public class PolygonBuilderEditor
+{
+    private bool show = false;
+    private PolygonBuilder.Options options;
+
+    public PolygonBuilderEditor()
+    {
+        options = new PolygonBuilder.Options();
+    }
+
+    public PolygonBuilder.Options OnInspectorGUI()
+    {
+        show = EditorGUILayout.Foldout(show, "Polygon builder options");
+        if (!show)
+        {
+            return options;
+        }
+
+        return options;
+    }
+}

--- a/Assets/Editor/PolygonBuilderEditor.cs
+++ b/Assets/Editor/PolygonBuilderEditor.cs
@@ -1,15 +1,24 @@
 using UnityEngine;
 using UnityEditor;
 using Mapzen;
+using System;
 
 public class PolygonBuilderEditor
 {
     private bool show = false;
     private PolygonBuilder.Options options;
+    private string maxHeight;
+
+    private static GUILayoutOption layoutWidth = GUILayout.Width(200);
 
     public PolygonBuilderEditor()
     {
         options = new PolygonBuilder.Options();
+
+        options.Extrude = true;
+        options.MaxHeight = 0.0f;
+
+        maxHeight = options.MaxHeight.ToString();
     }
 
     public PolygonBuilder.Options OnInspectorGUI()
@@ -19,6 +28,25 @@ public class PolygonBuilderEditor
         {
             return options;
         }
+
+        GUILayout.BeginHorizontal();
+        {
+            GUILayout.Label("Max Height: ");
+            maxHeight = GUILayout.TextField(maxHeight, layoutWidth);
+            try {
+                options.MaxHeight = float.Parse(maxHeight);
+            } catch (FormatException) {
+                Debug.Log("Invalid number given for PolygonBuilder.MaxHeight");
+            }
+        }
+        GUILayout.EndHorizontal();
+
+        GUILayout.BeginHorizontal();
+        {
+            GUILayout.Label("Extrude: ");
+            options.Extrude = GUILayout.Toggle(options.Extrude, "Extrude", layoutWidth);
+        }
+        GUILayout.EndHorizontal();
 
         return options;
     }

--- a/Assets/Editor/PolygonBuilderEditor.cs.meta
+++ b/Assets/Editor/PolygonBuilderEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 380ea23500a1d4b37a07202fffb702fc
+timeCreated: 1500930794
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/PolylineBuilderEditor.cs
+++ b/Assets/Editor/PolylineBuilderEditor.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using UnityEditor;
+using Mapzen;
+
+public class PolylineBuilderEditor
+{
+    private bool show = false;
+    private PolylineBuilder.Options options;
+
+    public PolylineBuilderEditor()
+    {
+        options = new PolylineBuilder.Options();
+    }
+
+    public PolylineBuilder.Options OnInspectorGUI()
+    {
+        show = EditorGUILayout.Foldout(show, "Polyline builder options");
+        if (!show)
+        {
+            return options;
+        }
+
+        return options;
+    }
+}

--- a/Assets/Editor/PolylineBuilderEditor.cs
+++ b/Assets/Editor/PolylineBuilderEditor.cs
@@ -36,24 +36,14 @@ public class PolylineBuilderEditor
         GUILayout.BeginHorizontal();
         {
             GUILayout.Label("Width ");
-            width = GUILayout.TextField(width, layoutWidth);
-            try {
-                options.Width = float.Parse(width);
-            } catch (FormatException) {
-                Debug.Log("Invalid number given for PolylineBuilder.Width");
-            }
+            EditorUtil.FloatField(ref width, ref options.Width, layoutWidth);
         }
         GUILayout.EndHorizontal();
 
         GUILayout.BeginHorizontal();
         {
             GUILayout.Label("Max Height: ");
-            maxHeight = GUILayout.TextField(maxHeight, layoutWidth);
-            try {
-                options.MaxHeight = float.Parse(maxHeight);
-            } catch (FormatException) {
-                Debug.Log("Invalid number given for PolylineBuilder.MaxHeight");
-            }
+            EditorUtil.FloatField(ref maxHeight, ref options.MaxHeight, layoutWidth);
         }
         GUILayout.EndHorizontal();
 

--- a/Assets/Editor/PolylineBuilderEditor.cs
+++ b/Assets/Editor/PolylineBuilderEditor.cs
@@ -1,15 +1,28 @@
 using UnityEngine;
 using UnityEditor;
 using Mapzen;
+using System;
 
 public class PolylineBuilderEditor
 {
     private bool show = false;
     private PolylineBuilder.Options options;
+    private string maxHeight;
+    private string width;
+
+    private static GUILayoutOption layoutWidth = GUILayout.Width(200);
 
     public PolylineBuilderEditor()
     {
         options = new PolylineBuilder.Options();
+
+        options.Extrude = true;
+        options.MaxHeight = 3.0f;
+        options.MiterLimit = 3.0f;
+        options.Width = 15.0f;
+
+        maxHeight = options.MaxHeight.ToString();
+        width = options.Width.ToString();
     }
 
     public PolylineBuilder.Options OnInspectorGUI()
@@ -19,6 +32,37 @@ public class PolylineBuilderEditor
         {
             return options;
         }
+
+        GUILayout.BeginHorizontal();
+        {
+            GUILayout.Label("Width ");
+            width = GUILayout.TextField(width, layoutWidth);
+            try {
+                options.Width = float.Parse(width);
+            } catch (FormatException) {
+                Debug.Log("Invalid number given for PolylineBuilder.Width");
+            }
+        }
+        GUILayout.EndHorizontal();
+
+        GUILayout.BeginHorizontal();
+        {
+            GUILayout.Label("Max Height: ");
+            maxHeight = GUILayout.TextField(maxHeight, layoutWidth);
+            try {
+                options.MaxHeight = float.Parse(maxHeight);
+            } catch (FormatException) {
+                Debug.Log("Invalid number given for PolylineBuilder.MaxHeight");
+            }
+        }
+        GUILayout.EndHorizontal();
+
+        GUILayout.BeginHorizontal();
+        {
+            GUILayout.Label("Extrude: ");
+            options.Extrude = GUILayout.Toggle(options.Extrude, "Extrude", layoutWidth);
+        }
+        GUILayout.EndHorizontal();
 
         return options;
     }

--- a/Assets/Editor/PolylineBuilderEditor.cs.meta
+++ b/Assets/Editor/PolylineBuilderEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0af68d1d0a17647b6a25209cd30b9bfe
+timeCreated: 1500930794
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/TileDataEditor.cs
+++ b/Assets/Editor/TileDataEditor.cs
@@ -1,0 +1,128 @@
+using UnityEngine;
+using UnityEditor;
+using Mapzen;
+using System.IO;
+using System;
+
+public class TileDataEditor
+{
+    private bool show = false;
+
+    public void OnInspectorGUI(MapzenMap mapzenMap)
+    {
+        show = EditorGUILayout.Foldout(show, "Tile data");
+        if (!show)
+        {
+            return;
+        }
+
+        if (GUILayout.Button("Download"))
+        {
+            ClearTiles(mapzenMap);
+            mapzenMap.DownloadTiles();
+        }
+
+        GUILayout.Label("Export path:");
+        mapzenMap.ExportPath = GUILayout.TextField(mapzenMap.ExportPath);
+        if (GUILayout.Button("Export"))
+        {
+            ExportGameObjects(mapzenMap);
+        }
+
+        if (GUILayout.Button("Clear"))
+        {
+            ClearTiles(mapzenMap);
+        }
+    }
+
+    public void ClearTiles(MapzenMap mapzenMap)
+    {
+        for (int i = 0; i < mapzenMap.Tiles.Count; ++i)
+        {
+            GameObject.DestroyImmediate(mapzenMap.Tiles[i]);
+        }
+        mapzenMap.Tiles.Clear();
+    }
+
+    private void ExportGameObjects(MapzenMap mapzenMap)
+    {
+        if (!CreateDirectoryAtPath(mapzenMap.ExportPath))
+        {
+            EditorUtility.DisplayDialog("Please provide a valid export path",
+                "Unable to create or locate directory at path" + mapzenMap.ExportPath,
+                "Ok");
+
+            return;
+        }
+
+        for (int i = 0; i < mapzenMap.Tiles.Count; ++i)
+        {
+            var tile = mapzenMap.Tiles[i];
+
+            float progress = (float)(i + 1) / mapzenMap.Tiles.Count;
+            EditorUtility.DisplayProgressBar("Exporting tile assets",
+                "Exporting tile asset " + tile.name,
+                progress);
+
+            string tileAssetPath = mapzenMap.ExportPath + "/" + tile.name;
+
+            if (CreateDirectoryAtPath(tileAssetPath))
+            {
+                SaveGameObjectToDisk(tile, tileAssetPath);
+            }
+            else
+            {
+                Debug.LogError("Unable to save tile at path " + tileAssetPath);
+            }
+        }
+
+        EditorUtility.ClearProgressBar();
+    }
+
+    private void SaveGameObjectToDisk(GameObject go, string rootPath)
+    {
+        var prefab = PrefabUtility.CreateEmptyPrefab(rootPath + "/" + go.name + ".prefab");
+        var serializedPrefab = PrefabUtility.ReplacePrefab(go, prefab, ReplacePrefabOptions.ConnectToPrefab);
+
+        var meshFilter = go.GetComponent<MeshFilter>().sharedMesh;
+        var materials = go.GetComponent<MeshRenderer>().materials;
+
+        serializedPrefab.GetComponent<MeshFilter>().mesh = meshFilter;
+        serializedPrefab.GetComponent<MeshRenderer>().materials = materials;
+
+        for (int i = 0; i < materials.Length; ++i)
+        {
+            // TODO: give better name to materials
+            AssetDatabase.CreateAsset(materials[i], rootPath + "/" + materials[i].name + i + ".mat");
+        }
+
+        AssetDatabase.CreateAsset(meshFilter, rootPath + "/" + go.name + ".asset");
+        AssetDatabase.SaveAssets();
+    }
+
+    private static bool CreateDirectoryAtPath(string path)
+    {
+        if (path == "")
+        {
+            return false;
+        }
+
+        if (Directory.Exists(path))
+        {
+            return true;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(path);
+            return true;
+        }
+        catch (Exception e)
+        {
+            Debug.Log(e);
+        }
+
+        return false;
+    }
+
+}

--- a/Assets/Editor/TileDataEditor.cs.meta
+++ b/Assets/Editor/TileDataEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a006a4932e8654a0ab8782317f9abca5
+timeCreated: 1500995876
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Generated.meta
+++ b/Assets/Generated.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: 5e9c3aa0dc02f4bce8bb7cf1ce680b43
-folderAsset: yes
-timeCreated: 1499979894
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Generated.meta
+++ b/Assets/Generated.meta
@@ -1,7 +1,7 @@
 fileFormatVersion: 2
-guid: 9ec307826e58445d1896cd01fbde1685
+guid: 5e9c3aa0dc02f4bce8bb7cf1ce680b43
 folderAsset: yes
-timeCreated: 1499809670
+timeCreated: 1499979894
 licenseType: Free
 DefaultImporter:
   userData: 

--- a/Assets/Generated.meta
+++ b/Assets/Generated.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9ec307826e58445d1896cd01fbde1685
+folderAsset: yes
+timeCreated: 1499809670
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/MapTile.cs
+++ b/Assets/MapTile.cs
@@ -10,10 +10,6 @@ using SimpleJSON;
 [RequireComponent(typeof(MeshFilter), typeof(MeshRenderer))]
 public class MapTile : MonoBehaviour
 {
-    public void Awake()
-    {
-    }
-
     public void CreateUnityMesh(MeshData meshData, float offsetX, float offsetY)
     {
         var mesh = new Mesh();

--- a/Assets/MapTile.cs
+++ b/Assets/MapTile.cs
@@ -10,98 +10,11 @@ using SimpleJSON;
 [RequireComponent(typeof(MeshFilter), typeof(MeshRenderer))]
 public class MapTile : MonoBehaviour
 {
-    private MeshData meshData = new MeshData();
-
-    private Dictionary<IFeatureFilter, Material> featureStyling = new Dictionary<IFeatureFilter, Material>();
-
     public void Awake()
     {
-        // Filter that accepts all features in the "water" layer.
-        var waterLayerFilter = new FeatureFilter().TakeAllFromCollections("water");
-
-        // Filter that accepts all features in the "buildings" layer with a "height" property.
-        var buildingExtrusionFilter = new FeatureFilter().TakeAllFromCollections("buildings");
-
-        // Filter that accepts all features in the "earth" or "landuse" layers.
-        var landLayerFilter = new FeatureFilter().TakeAllFromCollections("earth", "landuse");
-
-        var roadLayerFilter = new FeatureFilter().TakeAllFromCollections("roads");
-
-        var baseMaterial = GetComponent<MeshRenderer>().material;
-
-        var waterMaterial = new Material(baseMaterial);
-        waterMaterial.color = Color.blue;
-
-        var buildingMaterial = new Material(baseMaterial);
-        buildingMaterial.color = Color.gray;
-
-        var landMaterial = new Material(baseMaterial);
-        landMaterial.color = Color.green;
-
-        var minorRoadsMaterial = new Material(baseMaterial);
-        minorRoadsMaterial.color = Color.white;
-
-        var highwayRoadsMaterial = new Material(baseMaterial);
-        highwayRoadsMaterial.color = Color.black;
-
-        featureStyling.Add(waterLayerFilter, waterMaterial);
-        featureStyling.Add(buildingExtrusionFilter, buildingMaterial);
-        featureStyling.Add(landLayerFilter, landMaterial);
-        featureStyling.Add(roadLayerFilter, minorRoadsMaterial);
     }
 
-    public void BuildMesh(double tileScale, IEnumerable<FeatureCollection> layers)
-    {
-        float inverseTileScale = 1.0f / (float)tileScale;
-
-        foreach (var entry in featureStyling)
-        {
-            var filter = entry.Key;
-            var material = entry.Value;
-
-            foreach (var layer in layers)
-            {
-                var filteredFeatures = filter.Filter(layer);
-
-                foreach (var feature in filteredFeatures)
-                {
-                    var options = new PolygonBuilder.Options();
-                    options.Material = material;
-
-                    object heightValue;
-                    if (feature.TryGetProperty("height", out heightValue) && heightValue is double)
-                    {
-                        // For some reason we can't cast heightValue straight to float.
-                        options.MaxHeight = (float)((double)heightValue * inverseTileScale);
-                        options.Extrude = true;
-                    }
-
-                    if (feature.Type == GeometryType.Polygon || feature.Type == GeometryType.MultiPolygon)
-                    {
-                        var builder = new PolygonBuilder(meshData, options);
-                        feature.HandleGeometry(builder);
-                    }
-
-                    if (feature.Type == GeometryType.LineString || feature.Type == GeometryType.MultiLineString)
-                    {
-                        var polylineOptions = new PolylineBuilder.Options();
-                        polylineOptions.Material = material;
-                        polylineOptions.Width = (float)(5.0 * inverseTileScale);
-                        polylineOptions.Extrude = true;
-                        polylineOptions.MaxHeight = (float)(3.0 * inverseTileScale);
-                        polylineOptions.MiterLimit = 3.0f;
-
-                        var builder = new PolylineBuilder(meshData, polylineOptions);
-                        feature.HandleGeometry(builder);
-                    }
-                }
-            }
-        }
-
-        meshData.FlipIndices();
-    }
-
-    public void CreateUnityMesh(float offsetX, float offsetY)
+    public void CreateUnityMesh(MeshData meshData, float offsetX, float offsetY)
     {
         var mesh = new Mesh();
 
@@ -119,10 +32,5 @@ public class MapTile : MonoBehaviour
 
         GetComponent<MeshFilter>().mesh = mesh;
         GetComponent<MeshRenderer>().materials = meshData.Submeshes.Select(s => s.Material).ToArray();
-    }
-
-    public void Update()
-    {
-        //transform.Rotate(Vector3.up, Time.deltaTime * 10.0f);
     }
 }

--- a/Assets/Mapzen/FeatureStyle.cs
+++ b/Assets/Mapzen/FeatureStyle.cs
@@ -19,10 +19,17 @@ namespace Mapzen
             internal set;
         }
 
-        public FeatureStyle(IFeatureFilter filter, Material material)
+        public PolygonBuilder.Options polygonBuilderOptions;
+        private PolylineBuilder.Options polylineBuilderOptions;
+
+        public FeatureStyle(IFeatureFilter filter, Material material,
+                            PolygonBuilder.Options polygonBuilderOptions,
+                            PolylineBuilder.Options polylineBuilderOptions)
         {
             this.Filter = filter;
             this.Material = material;
+            this.polygonBuilderOptions = polygonBuilderOptions;
+            this.polylineBuilderOptions = polylineBuilderOptions;
         }
 
         public PolygonBuilder.Options PolygonOptions(Feature feature, float inverseTileScale)
@@ -55,9 +62,10 @@ namespace Mapzen
 
             var polylineOptions = new PolylineBuilder.Options();
             polylineOptions.Material = this.Material;
-            polylineOptions.Width = 5.0f * inverseTileScale;
+            polylineOptions.Width = 15.0f * inverseTileScale;
             polylineOptions.Extrude = true;
             polylineOptions.MaxHeight = 3.0f * inverseTileScale;
+            polylineOptions.MiterLimit = 3.0f;
 
             return polylineOptions;
         }

--- a/Assets/Mapzen/FeatureStyle.cs
+++ b/Assets/Mapzen/FeatureStyle.cs
@@ -1,0 +1,65 @@
+using System;
+using Mapzen.VectorData.Filters;
+using Mapzen.VectorData;
+using UnityEngine;
+
+namespace Mapzen
+{
+    public class FeatureStyle
+    {
+        public IFeatureFilter Filter
+        {
+            get;
+            internal set;
+        }
+
+        public Material Material
+        {
+            get;
+            internal set;
+        }
+
+        public FeatureStyle(IFeatureFilter filter, Material material)
+        {
+            this.Filter = filter;
+            this.Material = material;
+        }
+
+        public PolygonBuilder.Options PolygonOptions(Feature feature, float inverseTileScale)
+        {
+            if (feature.Type != GeometryType.Polygon && feature.Type != GeometryType.MultiPolygon)
+            {
+                return null;
+            }
+
+            var polygonOptions = new PolygonBuilder.Options();
+
+            object heightValue;
+            if (feature.TryGetProperty("height", out heightValue) && heightValue is double)
+            {
+                polygonOptions.MaxHeight = (float)((double)heightValue * inverseTileScale);
+                polygonOptions.Extrude = true;
+            }
+
+            polygonOptions.Material = this.Material;
+
+            return polygonOptions;
+        }
+
+        public PolylineBuilder.Options PolylineOptions(Feature feature, float inverseTileScale)
+        {
+            if (feature.Type != GeometryType.LineString && feature.Type != GeometryType.MultiLineString)
+            {
+                return null;
+            }
+
+            var polylineOptions = new PolylineBuilder.Options();
+            polylineOptions.Material = this.Material;
+            polylineOptions.Width = 5.0f * inverseTileScale;
+            polylineOptions.Extrude = true;
+            polylineOptions.MaxHeight = 3.0f * inverseTileScale;
+
+            return polylineOptions;
+        }
+    }
+}

--- a/Assets/Mapzen/FeatureStyle.cs
+++ b/Assets/Mapzen/FeatureStyle.cs
@@ -34,40 +34,35 @@ namespace Mapzen
 
         public PolygonBuilder.Options PolygonOptions(Feature feature, float inverseTileScale)
         {
-            if (feature.Type != GeometryType.Polygon && feature.Type != GeometryType.MultiPolygon)
+            var options = polygonBuilderOptions;
+
+            options.Material = this.Material;
+
+            if (options.MaxHeight > 0.0f)
             {
-                return null;
+                options.MaxHeight *= inverseTileScale;
+            }
+            else
+            {
+                object heightValue;
+                if (feature.TryGetProperty("height", out heightValue) && heightValue is double)
+                {
+                    options.MaxHeight = (float)((double)heightValue * inverseTileScale);
+                }
             }
 
-            var polygonOptions = new PolygonBuilder.Options();
-
-            object heightValue;
-            if (feature.TryGetProperty("height", out heightValue) && heightValue is double)
-            {
-                polygonOptions.MaxHeight = (float)((double)heightValue * inverseTileScale);
-                polygonOptions.Extrude = true;
-            }
-
-            polygonOptions.Material = this.Material;
-
-            return polygonOptions;
+            return options;
         }
 
         public PolylineBuilder.Options PolylineOptions(Feature feature, float inverseTileScale)
         {
-            if (feature.Type != GeometryType.LineString && feature.Type != GeometryType.MultiLineString)
-            {
-                return null;
-            }
+            var options = polylineBuilderOptions;
 
-            var polylineOptions = new PolylineBuilder.Options();
-            polylineOptions.Material = this.Material;
-            polylineOptions.Width = 15.0f * inverseTileScale;
-            polylineOptions.Extrude = true;
-            polylineOptions.MaxHeight = 3.0f * inverseTileScale;
-            polylineOptions.MiterLimit = 3.0f;
+            options.Material = this.Material;
+            options.Width *= inverseTileScale;
+            options.MaxHeight *= inverseTileScale;
 
-            return polylineOptions;
+            return options;
         }
     }
 }

--- a/Assets/Mapzen/FeatureStyle.cs.meta
+++ b/Assets/Mapzen/FeatureStyle.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0eb0cbbdcd42b4a18805177b7dc9da97
+timeCreated: 1500668439
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Mapzen/PolygonBuilder.cs
+++ b/Assets/Mapzen/PolygonBuilder.cs
@@ -6,7 +6,7 @@ namespace Mapzen
 {
     public class PolygonBuilder : IGeometryHandler
     {
-        public struct Options
+        public class Options
         {
             public Material Material;
             public bool Extrude;

--- a/Assets/Mapzen/PolygonBuilder.cs
+++ b/Assets/Mapzen/PolygonBuilder.cs
@@ -6,7 +6,7 @@ namespace Mapzen
 {
     public class PolygonBuilder : IGeometryHandler
     {
-        public class Options
+        public struct Options
         {
             public Material Material;
             public bool Extrude;

--- a/Assets/Mapzen/PolygonBuilder.cs
+++ b/Assets/Mapzen/PolygonBuilder.cs
@@ -106,14 +106,14 @@ namespace Mapzen
 
             earcut.Tesselate(coordinates.ToArray(), rings.ToArray());
 
-            var vertices = new List<Vector3>(earcut.vertices.Length / 2);
+            var vertices = new List<Vector3>(earcut.Vertices.Length / 2);
 
-            for (int i = 0; i < earcut.vertices.Length; i += 2)
+            for (int i = 0; i < earcut.Vertices.Length; i += 2)
             {
-                vertices.Add(new Vector3(earcut.vertices[i], options.MaxHeight, earcut.vertices[i + 1]));
+                vertices.Add(new Vector3(earcut.Vertices[i], options.MaxHeight, earcut.Vertices[i + 1]));
             }
 
-            outputMeshData.AddElements(vertices, earcut.indices, options.Material);
+            outputMeshData.AddElements(vertices, earcut.Indices, options.Material);
 
             earcut.Release();
         }

--- a/Assets/Mapzen/PolylineBuilder.cs
+++ b/Assets/Mapzen/PolylineBuilder.cs
@@ -11,7 +11,7 @@ namespace Mapzen
         private List<Vector2> polyline;
         private Options options;
 
-        public class Options
+        public struct Options
         {
             public Material Material;
             public bool Extrude;

--- a/Assets/Mapzen/PolylineBuilder.cs
+++ b/Assets/Mapzen/PolylineBuilder.cs
@@ -11,7 +11,7 @@ namespace Mapzen
         private List<Vector2> polyline;
         private Options options;
 
-        public struct Options
+        public class Options
         {
             public Material Material;
             public bool Extrude;

--- a/Assets/Mapzen/TileAddress.cs
+++ b/Assets/Mapzen/TileAddress.cs
@@ -118,7 +118,7 @@ namespace Mapzen
 
         public override string ToString()
         {
-            return String.Format("{0}/{1}/{2}", z, y, x);
+            return String.Format("{0}-{1}-{2}", z, y, x);
         }
     }
 }

--- a/Assets/MapzenMap.cs
+++ b/Assets/MapzenMap.cs
@@ -20,14 +20,14 @@ public class MapzenMap : MonoBehaviour
 
     private UnityIO tileIO = new UnityIO();
 
+    [SerializeField]
+    private Dictionary<IFeatureFilter, Material> featureStyling = new Dictionary<IFeatureFilter, Material>();
+
     public void DownloadTiles()
     {
-        tiles.Clear();
-
         GameObject tilePrefab = Resources.Load("Tile") as GameObject;
 
-        Dictionary<IFeatureFilter, Material> featureStyling = new Dictionary<IFeatureFilter, Material>();
-
+        /*
         // Filter that accepts all features in the "water" layer.
         var waterLayerFilter = new FeatureFilter().TakeAllFromCollections("water");
 
@@ -37,7 +37,8 @@ public class MapzenMap : MonoBehaviour
         // Filter that accepts all features in the "earth" or "landuse" layers.
         var landLayerFilter = new FeatureFilter().TakeAllFromCollections("earth", "landuse");
 
-        var roadLayerFilter = new FeatureFilter().TakeAllFromCollections("roads");
+        var minorRoadLayerFilter = new FeatureFilter().TakeAllFromCollections("roads").Where(FeatureMatcher.HasPropertyWithValue("kind", "minor_road"));
+        var highwayRoadLayerFilter = new FeatureFilter().TakeAllFromCollections("roads").Where(FeatureMatcher.HasPropertyWithValue("kind", "highway"));
 
         var baseMaterial = GetComponent<MeshRenderer>().material;
 
@@ -59,7 +60,9 @@ public class MapzenMap : MonoBehaviour
         featureStyling.Add(waterLayerFilter, waterMaterial);
         featureStyling.Add(buildingExtrusionFilter, buildingMaterial);
         featureStyling.Add(landLayerFilter, landMaterial);
-        featureStyling.Add(roadLayerFilter, minorRoadsMaterial);
+        featureStyling.Add(minorRoadLayerFilter, minorRoadsMaterial);
+        featureStyling.Add(highwayRoadLayerFilter, highwayRoadsMaterial);
+        */
 
         TileBounds bounds = new TileBounds(Area);
 
@@ -117,6 +120,12 @@ public class MapzenMap : MonoBehaviour
         {
             return tiles;
         }
+    }
+
+
+    public Dictionary<IFeatureFilter, Material> FeatureStyling
+    {
+        get { return featureStyling; }
     }
 
     public string ExportPath

--- a/Assets/MapzenMap.cs
+++ b/Assets/MapzenMap.cs
@@ -25,7 +25,6 @@ public class MapzenMap : MonoBehaviour
 
     public void DownloadTiles()
     {
-        GameObject tilePrefab = Resources.Load("Tile") as GameObject;
 
         /*
         // Filter that accepts all features in the "water" layer.
@@ -65,6 +64,7 @@ public class MapzenMap : MonoBehaviour
         */
 
         TileBounds bounds = new TileBounds(Area);
+        GameObject tilePrefab = Resources.Load("Tile") as GameObject;
 
         foreach (var tileAddress in bounds.TileAddressRange)
         {
@@ -88,9 +88,6 @@ public class MapzenMap : MonoBehaviour
                     return;
                 }
 
-                // Adding a tile object to the scene
-                GameObject tilePrefab = Resources.Load("Tile") as GameObject;
-
                 // Instantiate a prefab running the script TileData.Start()
                 var go = Instantiate(tilePrefab);
 
@@ -99,8 +96,8 @@ public class MapzenMap : MonoBehaviour
 
                 MapTile tile = go.GetComponent<MapTile>();
 
-                float offsetX = (tileAddress.x - TileX);
-                float offsetY = (-tileAddress.y + TileY);
+                float offsetX = (tileAddress.x - bounds.min.x);
+                float offsetY = (-tileAddress.y + bounds.min.y);
 
                 TileTask task = new TileTask(tileAddress, response, offsetX, offsetY);
                 task.Start(featureStyling);

--- a/Assets/MapzenMap.cs
+++ b/Assets/MapzenMap.cs
@@ -25,7 +25,7 @@ public class MapzenMap : MonoBehaviour
     private UnityIO tileIO = new UnityIO();
 
     [SerializeField]
-    private Dictionary<IFeatureFilter, Material> featureStyling = new Dictionary<IFeatureFilter, Material>();
+    private List<FeatureStyle> featureStyling = new List<FeatureStyle>();
 
     public void DownloadTiles()
     {
@@ -86,7 +86,7 @@ public class MapzenMap : MonoBehaviour
     }
 
 
-    public Dictionary<IFeatureFilter, Material> FeatureStyling
+    public List<FeatureStyle> FeatureStyling
     {
         get { return featureStyling; }
     }

--- a/Assets/MapzenMap.cs
+++ b/Assets/MapzenMap.cs
@@ -12,7 +12,11 @@ public class MapzenMap : MonoBehaviour
 {
     public string ApiKey = "vector-tiles-tyHL4AY";
 
-    public TileArea Area = new TileArea(new LngLat(-74.014892578125, 40.70562793820589), new LngLat(-74.00390625, 40.713955826286046), 16);
+    public TileArea Area = new TileArea(
+        new LngLat(-74.014892578125, 40.70562793820589),
+        new LngLat(-74.00390625, 40.713955826286046),
+        16);
+
     private List<GameObject> tiles = new List<GameObject>();
 
     [SerializeField]
@@ -25,44 +29,6 @@ public class MapzenMap : MonoBehaviour
 
     public void DownloadTiles()
     {
-
-        /*
-        // Filter that accepts all features in the "water" layer.
-        var waterLayerFilter = new FeatureFilter().TakeAllFromCollections("water");
-
-        // Filter that accepts all features in the "buildings" layer with a "height" property.
-        var buildingExtrusionFilter = new FeatureFilter().TakeAllFromCollections("buildings");
-
-        // Filter that accepts all features in the "earth" or "landuse" layers.
-        var landLayerFilter = new FeatureFilter().TakeAllFromCollections("earth", "landuse");
-
-        var minorRoadLayerFilter = new FeatureFilter().TakeAllFromCollections("roads").Where(FeatureMatcher.HasPropertyWithValue("kind", "minor_road"));
-        var highwayRoadLayerFilter = new FeatureFilter().TakeAllFromCollections("roads").Where(FeatureMatcher.HasPropertyWithValue("kind", "highway"));
-
-        var baseMaterial = GetComponent<MeshRenderer>().material;
-
-        var waterMaterial = new Material(baseMaterial);
-        waterMaterial.color = Color.blue;
-
-        var buildingMaterial = new Material(baseMaterial);
-        buildingMaterial.color = Color.gray;
-
-        var landMaterial = new Material(baseMaterial);
-        landMaterial.color = Color.green;
-
-        var minorRoadsMaterial = new Material(baseMaterial);
-        minorRoadsMaterial.color = Color.white;
-
-        var highwayRoadsMaterial = new Material(baseMaterial);
-        highwayRoadsMaterial.color = Color.black;
-
-        featureStyling.Add(waterLayerFilter, waterMaterial);
-        featureStyling.Add(buildingExtrusionFilter, buildingMaterial);
-        featureStyling.Add(landLayerFilter, landMaterial);
-        featureStyling.Add(minorRoadLayerFilter, minorRoadsMaterial);
-        featureStyling.Add(highwayRoadLayerFilter, highwayRoadsMaterial);
-        */
-
         TileBounds bounds = new TileBounds(Area);
         GameObject tilePrefab = Resources.Load("Tile") as GameObject;
 

--- a/Assets/MapzenMap.cs
+++ b/Assets/MapzenMap.cs
@@ -20,6 +20,7 @@ public class MapzenMap : MonoBehaviour
     }
 
     public string ApiKey = "vector-tiles-tyHL4AY";
+    public bool SaveTilesOnDisk = false;
     public IMapzenMapListener Listener;
 
     public TileArea Area = new TileArea(new LngLat(-74.014892578125, 40.70562793820589), new LngLat(-74.00390625, 40.713955826286046), 16);

--- a/Assets/MapzenMap.cs
+++ b/Assets/MapzenMap.cs
@@ -13,16 +13,16 @@ public class MapzenMap : MonoBehaviour
     public string ApiKey = "vector-tiles-tyHL4AY";
 
     public TileArea Area = new TileArea(
-        new LngLat(-74.014892578125, 40.70562793820589),
-        new LngLat(-74.00390625, 40.713955826286046),
-        16);
+                               new LngLat(-74.014892578125, 40.70562793820589),
+                               new LngLat(-74.00390625, 40.713955826286046),
+                               16);
 
     private List<GameObject> tiles = new List<GameObject>();
 
+    private UnityIO tileIO = new UnityIO();
+
     [SerializeField]
     private string exportPath = "Assets/Generated";
-
-    private UnityIO tileIO = new UnityIO();
 
     [SerializeField]
     private List<FeatureStyle> featureStyling = new List<FeatureStyle>();
@@ -36,7 +36,7 @@ public class MapzenMap : MonoBehaviour
         {
             var wrappedTileAddress = tileAddress.Wrapped();
             var uri = new Uri(string.Format("https://tile.mapzen.com/mapzen/vector/v1/all/{0}/{1}/{2}.mvt?api_key={3}",
-                          wrappedTileAddress.z, wrappedTileAddress.x, wrappedTileAddress.y, ApiKey));
+                              wrappedTileAddress.z, wrappedTileAddress.x, wrappedTileAddress.y, ApiKey));
 
             Debug.Log("URL request " + uri.AbsoluteUri);
 
@@ -65,7 +65,7 @@ public class MapzenMap : MonoBehaviour
                 float offsetX = (tileAddress.x - bounds.min.x);
                 float offsetY = (-tileAddress.y + bounds.min.y);
 
-                TileTask task = new TileTask(tileAddress, response, offsetX, offsetY);
+                TileTask task = new TileTask(tileAddress, response.data, offsetX, offsetY);
                 task.Start(featureStyling);
                 tile.CreateUnityMesh(task.Data, offsetX, offsetY);
 

--- a/Assets/TileTask.cs
+++ b/Assets/TileTask.cs
@@ -3,36 +3,83 @@ using System.Collections.Generic;
 using Mapzen;
 using Mapzen.VectorData;
 using Mapzen.VectorData.Formats;
+using Mapzen.VectorData.Filters;
+using UnityEngine;
 
 public class TileTask
 {
     private TileAddress address;
     private byte[] response;
-    private MapTile tile;
     private bool ready;
 
-    // TODO: remove those offset once we have better tile placement
-    public float offsetX = 0.0f;
-    public float offsetY = 0.0f;
+    public float OffsetX { get; internal set; }
 
-    public TileTask(TileAddress address, byte[] response, MapTile tile)
+    public float OffsetY { get; internal set; }
+
+    public MeshData Data { get; internal set; }
+
+    public TileTask(TileAddress address, byte[] response, float offsetX, float offsetY)
     {
         this.address = address;
         this.response = response;
-        this.tile = tile;
-
+        this.Data = new MeshData();
+        this.OffsetX = offsetX;
+        this.OffsetY = offsetY;
         ready = false;
     }
 
-    public void Start()
+    public void Start(Dictionary<IFeatureFilter, Material> featureStyling)
     {
-
         // Parse the GeoJSON
         // var tileData = new GeoJsonTile(address, response);
         var tileData = new MvtTile(address, response);
 
-        // Tesselate the mesh
-        tile.BuildMesh(address.GetSizeMercatorMeters(), tileData.FeatureCollections);
+        float inverseTileScale = 1.0f / (float)address.GetSizeMercatorMeters();
+
+        foreach (var entry in featureStyling)
+        {
+            var filter = entry.Key;
+            var material = entry.Value;
+
+            foreach (var layer in tileData.FeatureCollections)
+            {
+                var filteredFeatures = filter.Filter(layer);
+
+                foreach (var feature in filteredFeatures)
+                {
+                    var options = new PolygonBuilder.Options();
+                    options.Material = material;
+
+                    object heightValue;
+                    if (feature.TryGetProperty("height", out heightValue) && heightValue is double)
+                    {
+                        // For some reason we can't cast heightValue straight to float.
+                        options.MaxHeight = (float)((double)heightValue * inverseTileScale);
+                        options.Extrude = true;
+                    }
+
+                    if (feature.Type == GeometryType.Polygon)
+                    {
+                        var builder = new PolygonBuilder(Data, options);
+                        feature.HandleGeometry(builder);
+                    }
+
+                    if (feature.Type == GeometryType.LineString)
+                    {
+                        var polylineOptions = new PolylineBuilder.Options();
+                        polylineOptions.Material = material;
+                        polylineOptions.Width = (float)(5.0 * inverseTileScale);
+                        polylineOptions.Extrude = true;
+                        polylineOptions.MaxHeight = (float)(3.0 * inverseTileScale);
+
+                        var builder = new PolylineBuilder(Data, polylineOptions);
+                        feature.HandleGeometry(builder);
+                    }
+                }
+            }
+        }
+
+        Data.FlipIndices();
 
         ready = true;
     }
@@ -40,10 +87,5 @@ public class TileTask
     public bool IsReady()
     {
         return ready;
-    }
-
-    public MapTile GetMapTile()
-    {
-        return tile;
     }
 }

--- a/Assets/TileTask.cs
+++ b/Assets/TileTask.cs
@@ -46,16 +46,16 @@ public class TileTask
 
                 foreach (var feature in filteredFeatures)
                 {
-                    var polygonOptions = style.PolygonOptions(feature, inverseTileScale);
-                    if (polygonOptions != null)
+                    if (feature.Type == GeometryType.Polygon || feature.Type == GeometryType.MultiPolygon)
                     {
+                        var polygonOptions = style.PolygonOptions(feature, inverseTileScale);
                         var builder = new PolygonBuilder(Data, polygonOptions);
                         feature.HandleGeometry(builder);
                     }
 
-                    var polylineOptions = style.PolylineOptions(feature, inverseTileScale);
-                    if (polylineOptions != null)
+                    if (feature.Type == GeometryType.LineString || feature.Type == GeometryType.MultiLineString)
                     {
+                        var polylineOptions = style.PolylineOptions(feature, inverseTileScale);
                         var builder = new PolylineBuilder(Data, polylineOptions);
                         feature.HandleGeometry(builder);
                     }

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -162,19 +162,4 @@ QualitySettings:
     asyncUploadTimeSlice: 2
     asyncUploadBufferSize: 4
     excludedTargetPlatforms: []
-  m_PerPlatformDefaultQuality:
-    Android: 2
-    Nintendo 3DS: 5
-    PS4: 5
-    PSM: 5
-    PSP2: 2
-    Samsung TV: 2
-    Standalone: 5
-    Tizen: 2
-    Web: 5
-    WebGL: 3
-    WiiU: 5
-    Windows Store Apps: 5
-    XboxOne: 5
-    iPhone: 2
-    tvOS: 5
+  m_PerPlatformDefaultQuality: {}


### PR DESCRIPTION
Add ability to export tiles in Editor mode only. This removes network dependency while using the plugin since the tile can be saved locally, and then used in any other project as game assets.

#### Select an area
<img width="374" alt="screen shot 2017-07-18 at 17 29 18" src="https://user-images.githubusercontent.com/7061573/28340741-ce406cf6-6bde-11e7-8bb9-78b5ea1e8c56.png">

As described in previous PR, we can select a bounding box described by a lat/lon which is the first step in order to generate the tiles.

#### Add filtering

Once an area is selected, we can add basic filtering. To facilitate understand of the available layers and since the would probably be not know by the user, I added those as presets, with a custom entry for custom data sources.

For now, a filter now only needs a collection of layer names and a material in order to be created.

<img width="374" alt="screen shot 2017-07-18 at 17 29 05" src="https://user-images.githubusercontent.com/7061573/28340746-d29fd804-6bde-11e7-9602-932c47cfc23f.png">

#### Export tile assets

When tiles are downloaded and generated, they are added to the scene. They can then be exported to a specific path. Material management will need to be improved, since right now a new material gets saved in each subfolder where the tile assets live, we should be able to share them in a common folder or reference the initial material used to create the filter.