### PR TITLE
Add PolygonBuilder options to tile UVs instead of stretching

### DIFF
--- a/Assets/Editor/PolygonBuilderEditor.cs
+++ b/Assets/Editor/PolygonBuilderEditor.cs
@@ -22,6 +22,7 @@ public class PolygonBuilderEditor : EditorBase
         var defaultOptions = new PolygonBuilder.Options();
 
         defaultOptions.Extrusion = PolygonBuilder.ExtrusionType.TopAndSides;
+        defaultOptions.UVMode = UVMode.Tile;
         defaultOptions.Enabled = true;
         defaultOptions.MaxHeight = 0.0f;
 
@@ -52,6 +53,7 @@ public class PolygonBuilderEditor : EditorBase
 
         options.MaxHeight = EditorGUILayout.FloatField("Max Height: ", options.MaxHeight);
         options.Extrusion = (PolygonBuilder.ExtrusionType)EditorGUILayout.EnumPopup("Extrusion type: ", options.Extrusion);
+        options.UVMode = (UVMode)EditorGUILayout.EnumPopup("UV Mode:", options.UVMode);
         options.Enabled = EditorGUILayout.Toggle("Enabled: ", options.Enabled);
 
         SavePreferences();

--- a/Assets/Mapzen/Unity/UVMode.cs
+++ b/Assets/Mapzen/Unity/UVMode.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace Mapzen.Unity
+{
+    /// <summary>
+    /// A UV mode determines how material texture coordinates are applied to the faces of polygons.
+    /// </summary>
+    [Serializable]
+    public enum UVMode
+    {
+        /// <summary>
+        /// Stretch the texture to fill the face of the polygon in both dimensions.
+        /// </summary>
+        Stretch,
+        /// <summary>
+        /// Repeat the texture in both dimensions to fill the face of the polygon without stretching.
+        /// </summary>
+        Tile,
+        /// <summary>
+        /// Stretch the texture horizontally and repeat it vertically.
+        /// </summary>
+        StretchUTileV,
+        /// <summary>
+        /// Repeat the texture vertically and stretch it horizontally.
+        /// </summary>
+        TileUStretchV,
+    }
+}

--- a/Assets/Mapzen/Unity/UVMode.cs.meta
+++ b/Assets/Mapzen/Unity/UVMode.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 4d064f44b5a654f38849ed45bef59393
+timeCreated: 1509662197
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Currently these options only apply to the UVs on extruded faces, but we can add Enum options to easily extend this.