### PR TITLE
Apply min_height property of features as MinHeight in PolygonOptions

### DIFF
--- a/Assets/Mapzen/Unity/LayerStyle.cs
+++ b/Assets/Mapzen/Unity/LayerStyle.cs
@@ -15,18 +15,26 @@ namespace Mapzen.Unity
         {
             var options = PolygonBuilder;
 
-            if (options.MaxHeight > 0.0f)
-            {
-                options.MaxHeight *= inverseTileScale;
-            }
-            else
+            if (options.MaxHeight == 0.0f)
             {
                 object heightValue;
                 if (feature.TryGetProperty("height", out heightValue) && heightValue is double)
                 {
-                    options.MaxHeight = (float)((double)heightValue * inverseTileScale);
+                    options.MaxHeight = (float)(double)heightValue;
                 }
             }
+
+            if (options.MinHeight == 0.0f)
+            {
+                object heightValue;
+                if (feature.TryGetProperty("min_height", out heightValue) && heightValue is double)
+                {
+                    options.MinHeight = (float)(double)heightValue;
+                }
+            }
+
+            options.MaxHeight *= inverseTileScale;
+            options.MinHeight *= inverseTileScale;
 
             return options;
         }


### PR DESCRIPTION
Doesn't apply if a non-zero MinHeight is set from the editor.